### PR TITLE
Add support for additional Git Providers.

### DIFF
--- a/nautobot_golden_config/utilities/git.py
+++ b/nautobot_golden_config/utilities/git.py
@@ -21,8 +21,14 @@ class GitRepo:
         self.path = obj.filesystem_path
         self.url = obj.remote_url
         self.token = obj._token
+        self.token_user = obj.username
         if self.token and self.token not in self.url:
-            self.url = re.sub("//", f"//{self.token}:x-oauth-basic@", self.url)
+            # Some Git Providers require a user as well as a token.
+            if self.token_user:
+                self.url = re.sub("//", f"//{self.token_user}:{self.token}@", self.url)
+            else:
+                # Github only requires the token.
+                self.url = re.sub("//", f"//{self.token}@", self.url)
 
         self.branch = obj.branch
         self.obj = obj


### PR DESCRIPTION
FIXES: #27 
Adds the GitRepo username from Nautobot and a check to see if the username is provided.  If provided, the url is modified to support both the token and the username.  If not, it will default to just using the Token.

Documentation can be found at https://nautobot.readthedocs.io/en/latest/models/extras/gitrepository/#repository-configuration