### PR TITLE
Fixes #63

### DIFF
--- a/nautobot_golden_config/nornir_plays/config_compliance.py
+++ b/nautobot_golden_config/nornir_plays/config_compliance.py
@@ -79,8 +79,16 @@ def run_compliance(  # pylint: disable=too-many-arguments,too-many-locals
 
     intended_file = os.path.join(intended_root_folder, intended_path_template_obj)
 
+    if not os.path.exists(intended_file):
+        logger.log_failure(obj, f"Unable to locate intended file for device at {intended_file}")
+        raise NornirNautobotException()
+
     backup_template = check_jinja_template(obj, logger, global_settings.backup_path_template)
     backup_file = os.path.join(backup_root_path, backup_template)
+
+    if not os.path.exists(backup_file):
+        logger.log_failure(obj, f"Unable to locate backup file for device at {backup_file}")
+        raise NornirNautobotException()
 
     platform = obj.platform.slug
     if not features.get(platform):


### PR DESCRIPTION
This should show an appropriate error in the job results when a backup or intended config file is missing. This should resolve issue #63.