### PR TITLE
Fix circular dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The plugin behavior can be controlled with the following list of settings.
 | enable_compliance | True | True | A boolean to represent whether or not to run the compliance process within the plugin. |
 | enable_intended | True | True | A boolean to represent whether or not to generate intended configurations within the plugin. |
 | enable_sotagg | True | True | A boolean to represent whether or not to provide a GraphQL query per device to allow the intended configuration to provide data variables to the plugin. |
-| platform_slug_map | {"cisco_aireos": "cisco_wlc"} | None | A dictionary in which the key is the platform slug and the value is what netutils uses in any "network_os" parameter. |
+| platform_slug_map | {"cisco_wlc": "cisco_aireos"} | None | A dictionary in which the key is the platform slug and the value is what netutils uses in any "network_os" parameter. |
 | sot_agg_transposer | mypkg.transposer | - | A string representation of a function that can post-process the graphQL data. |
 | per_feature_bar_width | 0.15 | 0.15 | The width of the table bar within the overview report | 
 | per_feature_width | 13 | 13 | The width in inches that the overview table can be. | 

--- a/nautobot_golden_config/models.py
+++ b/nautobot_golden_config/models.py
@@ -18,7 +18,7 @@ from nautobot.core.models.generics import PrimaryModel
 from netutils.config.compliance import feature_compliance
 
 from nautobot_golden_config.choices import ComplianceRuleTypeChoice
-from nautobot_golden_config.utilities.helper import get_platform
+from nautobot_golden_config.utilities.utils import get_platform
 
 LOGGER = logging.getLogger(__name__)
 GRAPHQL_STR_START = "query ($device_id: ID!)"

--- a/nautobot_golden_config/nornir_plays/config_compliance.py
+++ b/nautobot_golden_config/nornir_plays/config_compliance.py
@@ -20,11 +20,11 @@ from nautobot_plugin_nornir.constants import NORNIR_SETTINGS
 from nautobot_golden_config.models import ComplianceRule, ConfigCompliance, GoldenConfigSetting, GoldenConfig
 from nautobot_golden_config.utilities.helper import (
     get_job_filter,
-    get_platform,
     verify_global_settings,
     check_jinja_template,
 )
 from nautobot_golden_config.nornir_plays.processor import ProcessGoldenConfig
+from nautobot_golden_config.utilities.utils import get_platform
 
 
 InventoryPluginRegister.register("nautobot-inventory", NautobotORMInventory)

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -11,7 +11,6 @@ from nautobot.dcim.filters import DeviceFilterSet
 from nautobot.dcim.models import Device
 
 from nautobot_golden_config import models
-from nautobot_golden_config.utilities.constant import PLUGIN_CFG
 
 
 FIELDS = {
@@ -45,13 +44,6 @@ def get_job_filter(data=None):
 
     base_qs = models.GoldenConfigSetting.objects.first().get_queryset()
     return DeviceFilterSet(data=query, queryset=base_qs).qs
-
-
-def get_platform(platform):
-    """Helper method to map user defined platform slug to netutils named entity."""
-    if PLUGIN_CFG.get("platform_slug_map", {}).get(platform):
-        return PLUGIN_CFG["platform_slug_map"][platform]
-    return platform
 
 
 def null_to_empty(val):

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -1,12 +1,10 @@
 """Helper functions."""
 # pylint: disable=raise-missing-from
 
-from django.conf import settings
 from jinja2 import Template, StrictUndefined, UndefinedError
 from jinja2.exceptions import TemplateError, TemplateSyntaxError
 
 from nornir_nautobot.exceptions import NornirNautobotException
-from nornir_nautobot.plugins.tasks.dispatcher import _DEFAULT_DRIVERS_MAPPING
 from nautobot.dcim.filters import DeviceFilterSet
 from nautobot.dcim.models import Device
 

--- a/nautobot_golden_config/utilities/utils.py
+++ b/nautobot_golden_config/utilities/utils.py
@@ -1,0 +1,10 @@
+"""Utility functions."""
+
+from nautobot_golden_config.utilities.constant import PLUGIN_CFG
+
+
+def get_platform(platform):
+    """Utility method to map user defined platform slug to netutils named entity."""
+    if PLUGIN_CFG.get("platform_slug_map", {}).get(platform):
+        return PLUGIN_CFG["platform_slug_map"][platform]
+    return platform


### PR DESCRIPTION
There is a circular dependency between models.py and the helper.py due to the get_platform method found in #87. I've corrected this by moving it to its own file. I also found that the example in the README for the platform mapping was reversed so I've corrected that. There were also two unused imports that I've removed for pylint. The remaining test failures should be fixed once the nautobot_plugin_nornir PR that's open is merged.