### PR TITLE
safe escape for git creds from nautobot, fixes #93

### DIFF
--- a/nautobot_golden_config/utilities/git.py
+++ b/nautobot_golden_config/utilities/git.py
@@ -5,6 +5,7 @@ import re
 import logging
 
 from git import Repo
+from urllib.parse import quote
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,10 +26,10 @@ class GitRepo:
         if self.token and self.token not in self.url:
             # Some Git Providers require a user as well as a token.
             if self.token_user:
-                self.url = re.sub("//", f"//{self.token_user}:{self.token}@", self.url)
+                self.url = re.sub("//", f"//{quote(self.token_user, safe='')}:{quote(self.token, safe='')}@", self.url)
             else:
                 # Github only requires the token.
-                self.url = re.sub("//", f"//{self.token}@", self.url)
+                self.url = re.sub("//", f"//{quote(self.token, safe='')}@", self.url)
 
         self.branch = obj.branch
         self.obj = obj


### PR DESCRIPTION
Use the safe escape for git credentials from Nautobot. This uses the same fix that nautobot uses to safely escape any special yet valid git credentials (such as usernames that are email addresses). Nautobot ref: https://github.com/nautobot/nautobot/pull/425. 