### PR TITLE
fixes #110

### DIFF
--- a/nautobot_golden_config/models.py
+++ b/nautobot_golden_config/models.py
@@ -35,6 +35,7 @@ def null_to_empty(val):
     "custom_fields",
     "custom_validators",
     "export_templates",
+    "graphql",
     "relationships",
     "webhooks",
 )


### PR DESCRIPTION
Fixes the unittest that were failing, this is the one model that doesn't have a custom type defined in graphql/types.py so adding the decorator back.