### PR TITLE
Fixing missing and extra fields

### DIFF
--- a/nautobot_golden_config/models.py
+++ b/nautobot_golden_config/models.py
@@ -227,8 +227,8 @@ class ConfigCompliance(PrimaryModel):
             else:
                 self.compliance_int = 0
                 self.ordered = value["ordered_compliant"]
-                self.missing = null_to_empty(value["missing"])
-                self.extra = null_to_empty(value["extra"])
+            self.missing = null_to_empty(value["missing"])
+            self.extra = null_to_empty(value["extra"])
         super().save(*args, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
This fixes a certain edge case where configcompliance objects are set the first time we need to make sure the missing and extra fields are always set