### PR TITLE
Fix report bar chart overlap

### DIFF
--- a/nautobot_golden_config/templates/nautobot_golden_config/compliance_overview_report.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/compliance_overview_report.html
@@ -20,7 +20,7 @@
             {% if bar_chart is not None %}
                 {% block graphic  %}
                     <div id="content">
-                        <img src= "data:image/png;base64,{{ bar_chart|safe }}" >
+                        <img src="data:image/png;base64,{{ bar_chart|safe }}" style="width:100%">
                     </div>
                 {% endblock %}
             {% else %}


### PR DESCRIPTION
This fixes compliance report main bar chart overlap with search block.
This PR adds `style` to `img` setting `width` to `100%` (relative) so the bar chart will dynamically resize to any window size.

![obraz](https://user-images.githubusercontent.com/58683518/141755761-96fbd0e8-54b2-46a2-a3f0-784d625b818c.png)

![obraz](https://user-images.githubusercontent.com/58683518/141755871-64b2a654-16fb-421f-ba09-f5c3c9cb73b5.png)
