### PR TITLE
Expose non-device data via GraphQL

### DIFF
--- a/nautobot_golden_config/utilities/graphql.py
+++ b/nautobot_golden_config/utilities/graphql.py
@@ -33,7 +33,14 @@ def graph_ql_query(request, device, query):
     if result.invalid:
         LOGGER.warning("GraphQL - query executed unsuccessfully")
         return (400, result.to_dict())
-    data = result.data
+    result_data = result.data
+    data = result_data.get("device", {})
+    data['external_data'] = {}
+    for key in result_data.keys():
+       if key != 'device':
+          data['external_data'][key] = result_data.get(key,{})
+
+    
 
     data = data.get("device", {})
 

--- a/nautobot_golden_config/utilities/graphql.py
+++ b/nautobot_golden_config/utilities/graphql.py
@@ -42,7 +42,7 @@ def graph_ql_query(request, device, query):
 
     
 
-    data = data.get("device", {})
+
 
     if PLUGIN_CFG.get("sot_agg_transposer"):
         LOGGER.debug("GraphQL - tansform data with function: `%s`", str(PLUGIN_CFG.get("sot_agg_transposer")))


### PR DESCRIPTION
Allow query beyond device level, expose as "external_data"

Example, need data for all VRFs, not just ones attached via interface->address->vrf.

GraphQL:
```
query ($device_id: ID!) {
  vrfs { 
      id 
      name 
      prefixes { 
        id 
        prefix 
     } 
  }
  device(id: $device_id) {
    virtual_chassis {
      id
      name
      master {
        id
        name
      }
      members {
        id
        name
        primary_ip4 {
          address
        } 
      }
    }
.....
```

Any non device data is under  external_data
``` external_data.vrf.prefixes ```
