### PR TITLE
setup netmiko extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ dmypy.json
 
 # Editor
 .vscode/
+.history/
 
 ### macOS ###
 # General

--- a/nautobot_golden_config/nornir_plays/config_backup.py
+++ b/nautobot_golden_config/nornir_plays/config_backup.py
@@ -122,6 +122,10 @@ def config_backup(job_result, data, backup_root_folder):
             },
         ) as nornir_obj:
 
+            for dev in nornir_obj.inventory.hosts.keys():
+                """ setup netmiko extras per host in the inventory """
+                nornir_obj.inventory.hosts[dev].connection_options['netmiko'].extras = NORNIR_SETTINGS.get("netmiko_extras")
+
             nr_with_processors = nornir_obj.with_processors([ProcessGoldenConfig(logger)])
 
             nr_with_processors.run(

--- a/nautobot_golden_config/nornir_plays/config_compliance.py
+++ b/nautobot_golden_config/nornir_plays/config_compliance.py
@@ -147,6 +147,10 @@ def config_compliance(job_result, data, backup_root_path, intended_root_folder):
             },
         ) as nornir_obj:
 
+            for dev in nornir_obj.inventory.hosts.keys():
+                """ setup netmiko extras per host in the inventory """
+                nornir_obj.inventory.hosts[dev].connection_options['netmiko'].extras = NORNIR_SETTINGS.get("netmiko_extras")
+
             nr_with_processors = nornir_obj.with_processors([ProcessGoldenConfig(logger)])
 
             nr_with_processors.run(

--- a/nautobot_golden_config/nornir_plays/config_intended.py
+++ b/nautobot_golden_config/nornir_plays/config_intended.py
@@ -103,6 +103,10 @@ def config_intended(job_result, data, jinja_root_path, intended_root_folder):
             },
         ) as nornir_obj:
 
+            for dev in nornir_obj.inventory.hosts.keys():
+                """ setup netmiko extras per host in the inventory """
+                nornir_obj.inventory.hosts[dev].connection_options['netmiko'].extras = NORNIR_SETTINGS.get("netmiko_extras")
+
             nr_with_processors = nornir_obj.with_processors([ProcessGoldenConfig(logger)])
 
             # Run the Nornir Tasks


### PR DESCRIPTION
These are a few lines to setup netmiko extras in the nornir Inventory, tested and working fine to let us set: banner_timeout, global_delay_factor and conn_timeout for examples on extra netmiko settings.