### PR TITLE
Detailed Error Handling in get_job_filter helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 ---
 name: "CI"
-on:  # yamllint disable
+on: # yamllint disable
   - "push"
   - "pull_request"
 
@@ -100,7 +100,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
-        nautobot-version: ["1.0.1"]
+        nautobot-version: ["1.0.1", "1.1.6", "1.2.1"]
     runs-on: "ubuntu-20.04"
     env:
       INVOKE_NAUTOBOT_GOLDEN_CONFIG_PYTHON_VER: "${{ matrix.python-version }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
-        nautobot-version: ["1.0.1", "1.1.6", "1.2.1"]
+        nautobot-version: ["1.2.1"]
     runs-on: "ubuntu-20.04"
     env:
       INVOKE_NAUTOBOT_GOLDEN_CONFIG_PYTHON_VER: "${{ matrix.python-version }}"

--- a/tasks.py
+++ b/tasks.py
@@ -28,7 +28,7 @@ namespace = Collection("nautobot_golden_config")
 namespace.configure(
     {
         "nautobot_golden_config": {
-            "nautobot_ver": "1.0.1",
+            "nautobot_ver": "1.2.1",
             "project_name": "nautobot_golden_config",
             "python_ver": "3.7",
             "local": False,


### PR DESCRIPTION
Fixes #195 
- Update CI to test against more versions of Nautobot
- Update `tasks.py` to spin up Nautobot 1.2.1
- Add more error handling to `get_job_filter` to provide context around specific conditions
- Add tests to cover `get_job_filter`