### PR TITLE
backport slug to name fix for column headers

### DIFF
--- a/nautobot_golden_config/views.py
+++ b/nautobot_golden_config/views.py
@@ -188,7 +188,7 @@ class ConfigComplianceListView(generic.ObjectListView):
         return pivot(
             self.queryset,
             ["device", "device__name"],
-            "rule__feature__slug",
+            "rule__feature__name",
             "compliance_int",
             aggregation=Max,
         )


### PR DESCRIPTION
Fixes an issue in which a rule feature name that has a name different than the slug wouldn't render the proper compliance icons.  This makes the view match the table to use the "name" instead of having a mismatch of slug and name. 