### PR TITLE
Added close_connections in completed stage of processor

### DIFF
--- a/nautobot_golden_config/nornir_plays/processor.py
+++ b/nautobot_golden_config/nornir_plays/processor.py
@@ -23,6 +23,7 @@ class ProcessGoldenConfig(BaseLoggingProcessor):
         Returns:
             None
         """
+        host.close_connections()
         # Complex logic to see if the task exception is expected, which is depicted by
         # a sub task raising a NornirNautobotException.
         if result.failed:


### PR DESCRIPTION
This PR aims to update the golden config processor to close connections to host at the end of each host's task. Per @itdependsnetworks this seems to a better place to put it rather than in [nornir-nautobot](https://github.com/nautobot/nornir-nautobot/pull/59). (I will likely close the aforementioned PR once I get confirmation this is the path we want to take.) 

No logic is done here as `close_connections` does some of its own found [here](https://github.com/nornir-automation/nornir/blob/f882c11afbf400b303de5d1120dac8ce9a9cf634/nornir/core/inventory.py#L570). 