### PR TITLE
Decorator to clear DB connections in threads

### DIFF
--- a/nautobot_golden_config/nornir_plays/config_backup.py
+++ b/nautobot_golden_config/nornir_plays/config_backup.py
@@ -14,7 +14,7 @@ from nautobot_plugin_nornir.plugins.inventory.nautobot_orm import NautobotORMInv
 from nautobot_plugin_nornir.constants import NORNIR_SETTINGS
 from nautobot_plugin_nornir.utils import get_dispatcher
 
-
+from nautobot_golden_config.utilities.db_management import close_threaded_db_connections
 from nautobot_golden_config.utilities.helper import (
     get_device_to_settings_map,
     get_job_filter,
@@ -31,6 +31,7 @@ from nautobot_golden_config.nornir_plays.processor import ProcessGoldenConfig
 InventoryPluginRegister.register("nautobot-inventory", NautobotORMInventory)
 
 
+@close_threaded_db_connections
 def run_backup(  # pylint: disable=too-many-arguments
     task: Task, logger, device_to_settings_map, remove_regex_dict, replace_regex_dict
 ) -> Result:

--- a/nautobot_golden_config/nornir_plays/config_compliance.py
+++ b/nautobot_golden_config/nornir_plays/config_compliance.py
@@ -17,6 +17,7 @@ from nornir_nautobot.utils.logger import NornirLogger
 from nautobot_plugin_nornir.plugins.inventory.nautobot_orm import NautobotORMInventory
 from nautobot_plugin_nornir.constants import NORNIR_SETTINGS
 
+from nautobot_golden_config.utilities.db_management import close_threaded_db_connections
 from nautobot_golden_config.models import ComplianceRule, ConfigCompliance, GoldenConfigSetting, GoldenConfig
 from nautobot_golden_config.utilities.helper import (
     get_device_to_settings_map,
@@ -53,6 +54,7 @@ def diff_files(backup_file, intended_file):
         yield line
 
 
+@close_threaded_db_connections
 def run_compliance(  # pylint: disable=too-many-arguments,too-many-locals
     task: Task,
     logger,

--- a/nautobot_golden_config/nornir_plays/config_intended.py
+++ b/nautobot_golden_config/nornir_plays/config_intended.py
@@ -18,6 +18,7 @@ from nautobot_plugin_nornir.plugins.inventory.nautobot_orm import NautobotORMInv
 from nautobot_plugin_nornir.constants import NORNIR_SETTINGS
 from nautobot_plugin_nornir.utils import get_dispatcher
 
+from nautobot_golden_config.utilities.db_management import close_threaded_db_connections
 from nautobot_golden_config.models import GoldenConfigSetting, GoldenConfig
 from nautobot_golden_config.utilities.helper import (
     get_device_to_settings_map,
@@ -35,6 +36,7 @@ jinja_settings = Jinja2.get_default()
 jinja_env = jinja_settings.env
 
 
+@close_threaded_db_connections
 def run_template(  # pylint: disable=too-many-arguments
     task: Task, logger, device_to_settings_map, nautobot_job
 ) -> Result:

--- a/nautobot_golden_config/utilities/db_management.py
+++ b/nautobot_golden_config/utilities/db_management.py
@@ -7,9 +7,10 @@ def close_threaded_db_connections(func):
 
     def inner(*args, **kwargs):
         """Inner function."""
-        func(*args, **kwargs)
+        try:
+            func(*args, **kwargs)
 
-        for c in connections.all():
-            c.connection.close()
+        finally:
+            connections.close_all()
 
     return inner

--- a/nautobot_golden_config/utilities/db_management.py
+++ b/nautobot_golden_config/utilities/db_management.py
@@ -1,0 +1,14 @@
+"""Functions to manage DB related tasks."""
+from django.db import connections
+
+
+def close_threaded_db_connections(func):
+    """Decorator that clears idle DB connections in thread."""
+    def inner(*args, **kwargs):
+        """Inner function."""
+        func(*args, **kwargs)
+
+        for c in connections.all():
+            c.connection.close()
+
+    return inner

--- a/nautobot_golden_config/utilities/db_management.py
+++ b/nautobot_golden_config/utilities/db_management.py
@@ -4,6 +4,7 @@ from django.db import connections
 
 def close_threaded_db_connections(func):
     """Decorator that clears idle DB connections in thread."""
+
     def inner(*args, **kwargs):
         """Inner function."""
         func(*args, **kwargs)


### PR DESCRIPTION
It seems that Django does not stop correctly closing DB connections when opened in threads. Therefore manual intervention is needed. There are numerous reports found on the internet. Here is one example:

https://stackoverflow.com/questions/1303654/threaded-django-task-doesnt-automatically-handle-transactions-or-db-connections

This PR adds a decorator that handles DB connections.

This issue is related: https://github.com/nautobot/nautobot-plugin-nornir/issues/50
