### PR TITLE
Compliance Export Issue

### DIFF
--- a/nautobot_golden_config/views.py
+++ b/nautobot_golden_config/views.py
@@ -224,7 +224,7 @@ class ConfigComplianceListView(generic.ObjectListView):
             raise ValueError(f"Expecting one of 'N/A', 0, or 1, got {val}")
 
         csv_data = []
-        headers = sorted(list(models.ComplianceFeature.objects.values_list("name", flat=True).distinct()))
+        headers = sorted(list(models.ComplianceFeature.objects.values_list("slug", flat=True).distinct()))
         csv_data.append(",".join(list(["Device name"] + headers)))
         for obj in self.alter_queryset(None):
             # From all of the unique fields, obtain the columns, using list comprehension, add values per column,


### PR DESCRIPTION
List comprehension is not able to retrieve the value in the column when the header has a capital letter.  I'm not sure that this is the correct fix.  Currently headers are allowed to contain the same letters (eg - "AAA", "AaA", and "aaa"), but cannot be identical.

Currently exporting from Golden Config > Configuration Compliance breaks when there is a capital letter in the header of a compliance feature.