### PR TITLE
Fix display of device compliance feature

### DIFF
--- a/nautobot_golden_config/templates/nautobot_golden_config/compliance_device_report.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/compliance_device_report.html
@@ -107,7 +107,7 @@
             {% endif %}
 
         </tr>
-        {% if item.compliance and not item.rule.config_ordered %}
+        {% if not item.compliance %}
             <tr>
                 <td style="width:250px">Intended Configuration</td>
                 <td class="config_hover">


### PR DESCRIPTION
Observed that compliant features on a device showed a blank intended config section when the ordered rule was set to false. It was noticed that the display was dependent upon the config ordered setting.