### PR TITLE
Changed extends base.html to extends generic/object_detail.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,9 @@ $RECYCLE.BIN/
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# Jetbrains IDE configs
+.idea/
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'generic/object_list.html' %}
 {% load buttons %}
 {% load static %}
 {% load helpers %}


### PR DESCRIPTION
Fixes: #416 

Changed `extends 'base.html'` to `extends 'generic/object_detail.html'` in templates/goldenconfig_list.html