### PR TITLE
Add validation for Settings sot_agg_query

### DIFF
--- a/nautobot_golden_config/models.py
+++ b/nautobot_golden_config/models.py
@@ -546,7 +546,7 @@ class GoldenConfigSetting(PrimaryModel):  # pylint: disable=too-many-ancestors
 
         if self.sot_agg_query:
             LOGGER.debug("GraphQL - test  query start with: `%s`", GRAPHQL_STR_START)
-            if not str(self.sot_agg_query.query).startswith(GRAPHQL_STR_START):
+            if not str(self.sot_agg_query.query.lstrip()).startswith(GRAPHQL_STR_START):
                 raise ValidationError(f"The GraphQL query must start with exactly `{GRAPHQL_STR_START}`")
 
     def get_queryset(self):

--- a/nautobot_golden_config/models.py
+++ b/nautobot_golden_config/models.py
@@ -18,7 +18,7 @@ from netutils.config.compliance import feature_compliance
 
 from nautobot_golden_config.choices import ComplianceRuleTypeChoice
 from nautobot_golden_config.utilities.utils import get_platform
-from nautobot_golden_config.utilities.constant import PLUGIN_CFG
+from nautobot_golden_config.utilities.constant import PLUGIN_CFG, ENABLE_SOTAGG
 
 
 LOGGER = logging.getLogger(__name__)
@@ -540,6 +540,9 @@ class GoldenConfigSetting(PrimaryModel):  # pylint: disable=too-many-ancestors
     def clean(self):
         """Validate the scope and GraphQL query."""
         super().clean()
+
+        if ENABLE_SOTAGG and not self.sot_agg_query:
+            raise ValidationError("A GraphQL query must be defined when `ENABLE_SOTAGG` is True")
 
         if self.sot_agg_query:
             LOGGER.debug("GraphQL - test  query start with: `%s`", GRAPHQL_STR_START)

--- a/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
@@ -49,7 +49,8 @@
             <div class="modal-body">
             </div>
             <div class="modal-footer">
-                <a id="detail_view" class="btn btn-primary">Detailed View</a>
+                <!-- If the output is empty, then the detail view href will not be resolvable -->
+                {% if output %}<a id="detail_view" class="btn btn-primary">Detailed View</a>{% endif %}
                 <button id="close" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
             </div>
         </div>

--- a/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
@@ -50,7 +50,7 @@
             </div>
             <div class="modal-footer">
                 <!-- If the output is empty, then the detail view href will not be resolvable -->
-                {% if output %}<a id="detail_view" class="btn btn-primary">Detailed View</a>{% endif %}
+                <a id="detail_view" class="btn btn-primary">Detailed View</a>
                 <button id="close" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
             </div>
         </div>

--- a/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
@@ -49,7 +49,6 @@
             <div class="modal-body">
             </div>
             <div class="modal-footer">
-                <!-- If the output is empty, then the detail view href will not be resolvable -->
                 <a id="detail_view" class="btn btn-primary">Detailed View</a>
                 <button id="close" type="button" class="btn btn-default" data-dismiss="modal">Close</button>
             </div>

--- a/nautobot_golden_config/tests/forms/test_golden_config_settings.py
+++ b/nautobot_golden_config/tests/forms/test_golden_config_settings.py
@@ -2,7 +2,6 @@
 from unittest import mock
 
 from django.test import TestCase
-from django.core.exceptions import ValidationError
 
 from nautobot.extras.models import GitRepository, DynamicGroup
 from nautobot_golden_config.forms import GoldenConfigSettingFeatureForm

--- a/nautobot_golden_config/tests/forms/test_golden_config_settings.py
+++ b/nautobot_golden_config/tests/forms/test_golden_config_settings.py
@@ -1,6 +1,9 @@
 """Tests for Golden Configuration Settings Form."""
+from unittest import mock
 
 from django.test import TestCase
+from django.core.exceptions import ValidationError
+
 from nautobot.extras.models import GitRepository, DynamicGroup
 from nautobot_golden_config.forms import GoldenConfigSettingFeatureForm
 from nautobot_golden_config.models import GoldenConfigSetting
@@ -19,22 +22,43 @@ class GoldenConfigSettingFormTest(TestCase):
 
     def test_no_query_no_scope_success(self):
         """Testing GoldenConfigForm without specifying a unique scope or GraphQL Query."""
-        form = GoldenConfigSettingFeatureForm(
-            data={
-                "name": "test",
-                "slug": "test",
-                "weight": 1000,
-                "description": "Test description.",
-                "backup_repository": GitRepository.objects.get(name="test-backup-repo-1"),
-                "backup_path_template": "{{ obj.site.region.parent.slug }}/{{obj.name}}.cfg",
-                "intended_repository": GitRepository.objects.get(name="test-intended-repo-1"),
-                "intended_path_template": "{{ obj.site.slug }}/{{ obj.name }}.cfg",
-                "backup_test_connectivity": True,
-                "dynamic_group": DynamicGroup.objects.first()
-            }
-        )
-        self.assertTrue(form.is_valid())
-        self.assertTrue(form.save())
+        with mock.patch("nautobot_golden_config.models.ENABLE_SOTAGG", False):
+            form = GoldenConfigSettingFeatureForm(
+                data={
+                    "name": "test",
+                    "slug": "test",
+                    "weight": 1000,
+                    "description": "Test description.",
+                    "backup_repository": GitRepository.objects.get(name="test-backup-repo-1"),
+                    "backup_path_template": "{{ obj.site.region.parent.slug }}/{{obj.name}}.cfg",
+                    "intended_repository": GitRepository.objects.get(name="test-intended-repo-1"),
+                    "intended_path_template": "{{ obj.site.slug }}/{{ obj.name }}.cfg",
+                    "backup_test_connectivity": True,
+                    "dynamic_group": DynamicGroup.objects.first()
+                }
+            )
+            self.assertTrue(form.is_valid())
+            self.assertTrue(form.save())
+
+    def test_no_query_fail(self):
+        """Testing GoldenConfigForm without specifying a unique scope or GraphQL Query."""
+        with mock.patch("nautobot_golden_config.models.ENABLE_SOTAGG", True):
+            form = GoldenConfigSettingFeatureForm(
+                data={
+                    "name": "test",
+                    "slug": "test",
+                    "weight": 1000,
+                    "description": "Test description.",
+                    "backup_repository": GitRepository.objects.get(name="test-backup-repo-1"),
+                    "backup_path_template": "{{ obj.site.region.parent.slug }}/{{obj.name}}.cfg",
+                    "intended_repository": GitRepository.objects.get(name="test-intended-repo-1"),
+                    "intended_path_template": "{{ obj.site.slug }}/{{ obj.name }}.cfg",
+                    "backup_test_connectivity": True,
+                    "dynamic_group": DynamicGroup.objects.first()
+                }
+            )
+            self.assertFalse(form.is_valid())
+            self.assertEqual(form.errors["__all__"][0], "A GraphQL query must be defined when `ENABLE_SOTAGG` is True")
 
     def test_clean_up(self):
         """Transactional custom model, unable to use `get_or_create`.

--- a/nautobot_golden_config/tests/test_utilities/test_helpers.py
+++ b/nautobot_golden_config/tests/test_utilities/test_helpers.py
@@ -10,7 +10,7 @@ from nornir_nautobot.utils.logger import NornirLogger
 from jinja2 import exceptions as jinja_errors
 
 from nautobot.dcim.models import Device, Platform, Site
-from nautobot.extras.models import GitRepository, Status, DynamicGroup, Tag
+from nautobot.extras.models import GitRepository, Status, DynamicGroup, Tag, GraphQLQuery
 from nautobot_golden_config.models import GoldenConfigSetting
 from nautobot_golden_config.tests.conftest import create_device, create_orphan_device, create_helper_repo
 from nautobot_golden_config.utilities.helper import (
@@ -67,6 +67,16 @@ class HelpersTest(TestCase):  # pylint: disable=too-many-instance-attributes
             content_type=self.content_type,
             filter={},
         )
+        graphql_query = GraphQLQuery.objects.create(
+            name="testing",
+            query="""
+              query ($device_id: ID!) {
+                device(id: $device_id){
+                  name
+                }
+              }
+            """
+        )
         self.test_settings_a = GoldenConfigSetting.objects.create(
             name="test_a",
             slug="test_a",
@@ -77,6 +87,7 @@ class HelpersTest(TestCase):  # pylint: disable=too-many-instance-attributes
             jinja_repository=GitRepository.objects.get(name="test-jinja-repo"),
             # Limit scope to orphaned device only
             dynamic_group=dynamic_group1,
+            sot_agg_query=graphql_query,
         )
 
         self.test_settings_b = GoldenConfigSetting.objects.create(
@@ -89,6 +100,7 @@ class HelpersTest(TestCase):  # pylint: disable=too-many-instance-attributes
             jinja_repository=GitRepository.objects.get(name="test-jinja-repo-2"),
             # Limit scope to orphaned device only
             dynamic_group=dynamic_group2,
+            sot_agg_query=graphql_query,
         )
 
         self.test_settings_c = GoldenConfigSetting.objects.create(
@@ -100,6 +112,7 @@ class HelpersTest(TestCase):  # pylint: disable=too-many-instance-attributes
             intended_repository=GitRepository.objects.get(name="intended-parent_region-3"),
             jinja_repository=GitRepository.objects.get(name="test-jinja-repo-3"),
             dynamic_group=dynamic_group3,
+            sot_agg_query=graphql_query,
         )
 
         # Device.objects.all().delete()

--- a/nautobot_golden_config/tests/test_utilities/test_helpers.py
+++ b/nautobot_golden_config/tests/test_utilities/test_helpers.py
@@ -75,7 +75,7 @@ class HelpersTest(TestCase):  # pylint: disable=too-many-instance-attributes
                   name
                 }
               }
-            """
+            """,
         )
         self.test_settings_a = GoldenConfigSetting.objects.create(
             name="test_a",

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -80,7 +80,6 @@ class ConfigComplianceOverviewOverviewHelperTestCase(TestCase):
     @mock.patch("nautobot_golden_config.models.GoldenConfigSetting")
     def test_config_compliance_details_sotagg_error(self, mock_gc_setting, mock_get_device_to_settings_map, mock_graph_ql_query):
         device =  Device.objects.first()
-        #mock_gc_setting.sot_agg_query = "This is a mock query"
         mock_get_device_to_settings_map.return_value = {device.id: mock_gc_setting}
         mock_graph_ql_query.return_value = ("discard value", "This is a mock graphql result")
         request = self.client.get(f"/plugins/golden-config/config-compliance/details/{device.pk}/sotagg/")

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -66,8 +66,10 @@ class ConfigComplianceOverviewOverviewHelperTestCase(TestCase):
     @mock.patch.object(views, "graph_ql_query")
     @mock.patch.object(views, "get_device_to_settings_map")
     @mock.patch("nautobot_golden_config.models.GoldenConfigSetting")
-    def test_config_compliance_details_sotagg_error(self, mock_gc_setting, mock_get_device_to_settings_map, mock_graphql_query):
-        device =  Device.objects.first()
+    def test_config_compliance_details_sotagg_error(
+        self, mock_gc_setting, mock_get_device_to_settings_map, mock_graphql_query
+    ):
+        device = Device.objects.first()
         mock_gc_setting.sot_agg_query = None
         mock_get_device_to_settings_map.return_value = {device.id: mock_gc_setting}
         request = self.client.get(f"/plugins/golden-config/config-compliance/details/{device.pk}/sotagg/")
@@ -78,8 +80,10 @@ class ConfigComplianceOverviewOverviewHelperTestCase(TestCase):
     @mock.patch.object(views, "graph_ql_query")
     @mock.patch.object(views, "get_device_to_settings_map")
     @mock.patch("nautobot_golden_config.models.GoldenConfigSetting")
-    def test_config_compliance_details_sotagg_error(self, mock_gc_setting, mock_get_device_to_settings_map, mock_graph_ql_query):
-        device =  Device.objects.first()
+    def test_config_compliance_details_sotagg_no_error(
+        self, mock_gc_setting, mock_get_device_to_settings_map, mock_graph_ql_query
+    ):
+        device = Device.objects.first()
         mock_get_device_to_settings_map.return_value = {device.id: mock_gc_setting}
         mock_graph_ql_query.return_value = ("discard value", "This is a mock graphql result")
         request = self.client.get(f"/plugins/golden-config/config-compliance/details/{device.pk}/sotagg/")

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -73,7 +73,7 @@ class ConfigComplianceOverviewOverviewHelperTestCase(TestCase):
         mock_gc_setting.sot_agg_query = None
         mock_get_device_to_settings_map.return_value = {device.id: mock_gc_setting}
         request = self.client.get(f"/plugins/golden-config/config-compliance/details/{device.pk}/sotagg/")
-        expected = '{\n    &quot;Error&quot;: &quot;No saved `GraphQL Query` query was configured in the `Golden Config Setting`&quot;\n}'
+        expected = "{\n    &quot;Error&quot;: &quot;No saved `GraphQL Query` query was configured in the `Golden Config Setting`&quot;\n}"
         self.assertContains(request, expected)
         mock_graphql_query.assert_not_called()
 

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -1,11 +1,17 @@
 """Unit tests for nautobot_golden_config views."""
 
+from unittest import mock
+
 from django.test import TestCase
+from django.contrib.auth import get_user_model
 
 from nautobot.dcim.models import Device
 from nautobot_golden_config import views, models
 
 from .conftest import create_feature_rule_json, create_device_data
+
+
+User = get_user_model()
 
 
 class ConfigComplianceOverviewOverviewHelperTestCase(TestCase):
@@ -38,9 +44,46 @@ class ConfigComplianceOverviewOverviewHelperTestCase(TestCase):
             )
 
         self.ccoh = views.ConfigComplianceOverviewOverviewHelper
+        User.objects.create_superuser(username="views", password="incredible")
+        self.client.login(username="views", password="incredible")
 
     def test_plot_visual_no_devices(self):
 
         aggr = {"comp_percents": 0, "compliants": 0, "non_compliants": 0, "total": 0}
 
         self.assertEqual(self.ccoh.plot_visual(aggr), None)
+
+    @mock.patch.dict("nautobot_golden_config.tables.CONFIG_FEATURES", {"sotagg": True})
+    def test_config_compliance_list_view_with_sotagg_enabled(self):
+        request = self.client.get("/plugins/golden-config/golden/")
+        self.assertContains(request, '<i class="mdi mdi-code-json" title="SOT Aggregate Data"></i>')
+
+    @mock.patch.dict("nautobot_golden_config.tables.CONFIG_FEATURES", {"sotagg": False})
+    def test_config_compliance_list_view_with_sotagg_disabled(self):
+        request = self.client.get("/plugins/golden-config/golden/")
+        self.assertNotContains(request, '<i class="mdi mdi-code-json" title="SOT Aggregate Data"></i>')
+
+    @mock.patch.object(views, "graph_ql_query")
+    @mock.patch.object(views, "get_device_to_settings_map")
+    @mock.patch("nautobot_golden_config.models.GoldenConfigSetting")
+    def test_config_compliance_details_sotagg_error(self, mock_gc_setting, mock_get_device_to_settings_map, mock_graphql_query):
+        device =  Device.objects.first()
+        mock_gc_setting.sot_agg_query = None
+        mock_get_device_to_settings_map.return_value = {device.id: mock_gc_setting}
+        request = self.client.get(f"/plugins/golden-config/config-compliance/details/{device.pk}/sotagg/")
+        expected = '{\n    &quot;Error&quot;: &quot;No saved `GraphQL Query` query was configured in the `Golden Config Setting`&quot;\n}'
+        self.assertContains(request, expected)
+        mock_graphql_query.assert_not_called()
+
+    @mock.patch.object(views, "graph_ql_query")
+    @mock.patch.object(views, "get_device_to_settings_map")
+    @mock.patch("nautobot_golden_config.models.GoldenConfigSetting")
+    def test_config_compliance_details_sotagg_error(self, mock_gc_setting, mock_get_device_to_settings_map, mock_graph_ql_query):
+        device =  Device.objects.first()
+        #mock_gc_setting.sot_agg_query = "This is a mock query"
+        mock_get_device_to_settings_map.return_value = {device.id: mock_gc_setting}
+        mock_graph_ql_query.return_value = ("discard value", "This is a mock graphql result")
+        request = self.client.get(f"/plugins/golden-config/config-compliance/details/{device.pk}/sotagg/")
+        expected = "This is a mock graphql result"
+        self.assertContains(request, expected)
+        mock_graph_ql_query.assert_called()

--- a/nautobot_golden_config/views.py
+++ b/nautobot_golden_config/views.py
@@ -410,7 +410,11 @@ class ConfigComplianceDetails(ContentTypePermissionRequiredMixin, generic.View):
 
             settings = get_device_to_settings_map(queryset=Device.objects.filter(pk=device.pk))
             if device.id in settings:
-                _, output = graph_ql_query(request, device, settings[device.id].sot_agg_query.query)
+                sot_agg_query_setting = settings[device.id].sot_agg_query
+                if sot_agg_query_setting is not None:
+                    _, output = graph_ql_query(request, device, sot_agg_query_setting.query)
+                else:
+                    output = None
             else:
                 raise ObjectDoesNotExist(f"{device.name} does not map to a Golden Config Setting.")
 

--- a/nautobot_golden_config/views.py
+++ b/nautobot_golden_config/views.py
@@ -414,7 +414,7 @@ class ConfigComplianceDetails(ContentTypePermissionRequiredMixin, generic.View):
                 if sot_agg_query_setting is not None:
                     _, output = graph_ql_query(request, device, sot_agg_query_setting.query)
                 else:
-                    output = None
+                    output = {"Error": "No saved `GraphQL Query` query was configured in the `Golden Config Setting`"}
             else:
                 raise ObjectDoesNotExist(f"{device.name} does not map to a Golden Config Setting.")
 


### PR DESCRIPTION
This adds validation to the GoldenConfigSetting clean method for requiring sot_agg_query to have a value when the Plugin Config has SOTAGG_ENABLED set to True. This is to address the issue where the Golden Config home page has an SOTAGG icon with an invalid link.