### PR TITLE
Allows for custom kwargs to `get_secret_by_secret_group_slug`

### DIFF
--- a/nautobot_golden_config/utilities/config_postprocessing.py
+++ b/nautobot_golden_config/utilities/config_postprocessing.py
@@ -27,10 +27,9 @@ def get_secret_by_secret_group_slug(
     secrets_group_slug: str,
     secret_type: str,
     secret_access_type: Optional[str] = SecretsGroupAccessTypeChoices.TYPE_GENERIC,
+    **kwargs,
 ) -> Optional[str]:
     """Gets the secret from a Secret Group slug. To be used as a Jinja filter.
-
-    We assume that there is only one secret group corresponding to a model.
 
     Args:
         user (User): User object that performs API call to render push template with secrets.
@@ -52,6 +51,7 @@ def get_secret_by_secret_group_slug(
     return secrets_group.get_secret_value(
         access_type=secret_access_type,
         secret_type=secret_type,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
This is a simple addition to allow for custom kwargs to be sent to [`secret.get_value`](https://github.com/nautobot/nautobot/blob/develop/nautobot/extras/models/secrets.py#L146).

This is a partial solve for #448. To keep this filter simple it doesn't render the object itself due to not having to deal with object permissions, but rather allows for any kwarg to be passed to the filter directly instead of requiring it to be derived from an object.