### PR TITLE
Tune Dependabot

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,13 @@
+# Use `allow` to specify which dependencies to maintain
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    allow:
+      - dependency-type: "direct"
+    versioning-strategy: increase
+  - package-ecosystem: "pip"
+    directory: "/"
+    ignore:
+      - dependency-type: "indirect"


### PR DESCRIPTION
- For direct dependencies, ensure it increases the version for security updates
- For indirect dependencies, ignore them since the lock file will not be used anywhere when it comes to installing the app

Following: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file

In their examples they use the `schedule` setting but that only applies for using Dependabot like Renovate to auto-update your dependencies which we aren't looking for at this time. Security updates do not follow schedule: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates, https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval