### PR TITLE
Address Missing PR Limit on Indirect Dependencies

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -5,9 +5,11 @@ updates:
     directory: "/"
     allow:
       - dependency-type: "direct"
+    ignore:
+      - dependency-type: "indirect"
     versioning-strategy: "increase"
   - package-ecosystem: "pip"
     directory: "/"
-    ignore:
+    allow:
       - dependency-type: "indirect"
     open-pull-requests-limit: 0

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -10,3 +10,4 @@ updates:
     directory: "/"
     ignore:
       - dependency-type: "indirect"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
See: https://github.com/nautobot/nautobot-plugin-golden-config/pull/460#issuecomment-1494366184

Can't tell if https://github.com/nautobot/nautobot-plugin-golden-config/commit/fac7160ee860beadb27029cb5ecce13175768d1a would be a double negative reading https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file and https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit

This may need further tweaking but #460 should not have been opened. Not easy to test this 🤷.