### PR TITLE
Fix GoldenConfig list view and csv export

### DIFF
--- a/nautobot_golden_config/tables.py
+++ b/nautobot_golden_config/tables.py
@@ -5,7 +5,6 @@ from django.utils.html import format_html
 from django_tables2 import Column, LinkColumn, TemplateColumn
 from django_tables2.utils import A
 
-from nautobot.dcim.models import Device
 from nautobot.utilities.tables import (
     BaseTable,
     ToggleColumn,
@@ -237,14 +236,6 @@ class DeleteGoldenConfigTable(BaseTable):
 class GoldenConfigTable(BaseTable):
     """Table to display Config Management Status."""
 
-    def __init__(self, *args, **kwargs):
-        """Remove custom field columns from showing."""
-        super().__init__(*args, **kwargs)
-        for feature in list(self.base_columns.keys()):  # pylint: disable=no-member
-            if feature.startswith("cf_"):
-                self.base_columns.pop(feature)  # pylint: disable=no-member
-                self.sequence.remove(feature)
-
     pk = ToggleColumn()
     name = TemplateColumn(
         template_code="""<a href="{% url 'dcim:device' pk=record.pk %}">{{ record.name }}</a>""",
@@ -303,7 +294,7 @@ class GoldenConfigTable(BaseTable):
     class Meta(BaseTable.Meta):
         """Meta for class GoldenConfigTable."""
 
-        model = Device
+        model = models.GoldenConfig
         fields = actual_fields()
 
 

--- a/nautobot_golden_config/views.py
+++ b/nautobot_golden_config/views.py
@@ -20,7 +20,6 @@ from nautobot.core.views import generic
 from nautobot.dcim.filters import DeviceFilterSet
 from nautobot.dcim.forms import DeviceFilterForm
 from nautobot.dcim.models import Device
-from nautobot.extras.models import CustomField
 from nautobot.utilities.error_handlers import handle_protectederror
 from nautobot.utilities.forms import ConfirmationForm
 from nautobot.utilities.utils import csv_format
@@ -50,6 +49,7 @@ class GoldenConfigListView(generic.ObjectListView):
     filterset_form = DeviceFilterForm
     queryset = Device.objects.all()
     template_name = "nautobot_golden_config/goldenconfig_list.html"
+    action_buttons = ("export",)
 
     def extra_context(self):
         """Boilerplace code to modify data before returning."""
@@ -73,30 +73,31 @@ class GoldenConfigListView(generic.ObjectListView):
             compliance_last_attempt_date=F("goldenconfig__compliance_last_attempt_date"),
         )
 
+    @property
+    def dynamic_group_queryset(self):
+        """Return queryset of DynamicGroups associated with all GoldenConfigSettings."""
+        golden_config_device_queryset = Device.objects.none()
+        for setting in models.GoldenConfigSetting.objects.all():
+            golden_config_device_queryset = golden_config_device_queryset | setting.dynamic_group.members
+        return golden_config_device_queryset
+
     def queryset_to_csv(self):
         """Override nautobot default to account for using Device model for GoldenConfig data."""
-        csv_data = []
-        custom_fields = []
-
-        # Start with the column headers
-        headers = models.GoldenConfig.csv_headers.copy()
-
-        # Add custom field headers, if any
-        if hasattr(models.GoldenConfig, "_custom_field_data"):
-            for custom_field in CustomField.objects.get_for_model(models.GoldenConfig):
-                headers.append(custom_field.name)
-                custom_fields.append(custom_field.name)
-
-        csv_data.append(",".join(headers))
-
-        # Iterate through the queryset appending each object
-        for obj in self.alter_queryset(None):
-            data = obj.to_csv()
-
-            for custom_field in custom_fields:
-                data += (obj.cf.get(custom_field, ""),)
-
-            csv_data.append(csv_format(data))
+        golden_config_devices_in_scope = self.dynamic_group_queryset
+        csv_headers = models.GoldenConfig.csv_headers.copy()
+        # Exclude GoldenConfig entries no longer in scope
+        golden_config_entries_in_scope = models.GoldenConfig.objects.filter(device__in=golden_config_devices_in_scope)
+        golden_config_entries_as_csv = [csv_format(entry.to_csv()) for entry in golden_config_entries_in_scope]
+        # Account for devices in scope without GoldenConfig entries
+        commas = "," * (len(csv_headers) - 1)
+        devices_in_scope_without_golden_config_entries_as_csv = [
+            f"{device.name}{commas}" for device in golden_config_devices_in_scope.filter(goldenconfig__isnull=True)
+        ]
+        csv_data = (
+            [",".join(csv_headers)]
+            + golden_config_entries_as_csv
+            + devices_in_scope_without_golden_config_entries_as_csv
+        )
 
         return "\n".join(csv_data)
 


### PR DESCRIPTION
The GoldenConfig List View is based on the Device Model, and so Custom Fields and Relationships were included in the table displayed for the GoldenConfig view. The GoldenConfig view was left to use the Device Model, but the table is updated to use the GoldenConfig Model to use only its columns.

The GoldenConfig CSV export has been updated to export only GoldenConfig entries that are currently in scope by all DynamicGroups associated with any GoldenConfigSetting entry. Additionally, any device that is in scope but does not have a GoldenConfig entry will have a placeholder entry added.