### PR TITLE
Add Option to Update Config Context Repos

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -174,6 +174,7 @@ PLUGINS_CONFIG = {
         "enable_postprocessing": is_truthy(os.environ.get("ENABLE_POSTPROCESSING", True)),
         "postprocessing_callables": os.environ.get("POSTPROCESSING_CALLABLES", []),
         "postprocessing_subscribed": os.environ.get("POSTPROCESSING_SUBSCRIBED", []),
+        "sync_config_context_repos": is_truthy(os.environ.get("SYNC_CONFIG_CONTEXT_REPOS", False)),
         # The platform_slug_map maps an arbitrary platform slug to its corresponding parser.
         # Use this if the platform slug names in your Nautobot instance don't correspond exactly
         # to the Nornir driver names ("arista_eos", "cisco_ios", etc.).

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -174,7 +174,7 @@ PLUGINS_CONFIG = {
         "enable_postprocessing": is_truthy(os.environ.get("ENABLE_POSTPROCESSING", True)),
         "postprocessing_callables": os.environ.get("POSTPROCESSING_CALLABLES", []),
         "postprocessing_subscribed": os.environ.get("POSTPROCESSING_SUBSCRIBED", []),
-        "sync_config_context_repos": is_truthy(os.environ.get("SYNC_CONFIG_CONTEXT_REPOS", False)),
+        "enable_config_context_sync": is_truthy(os.environ.get("ENABLE_CONFIG_CONTEXT_SYNC", False)),
         # The platform_slug_map maps an arbitrary platform slug to its corresponding parser.
         # Use this if the platform slug names in your Nautobot instance don't correspond exactly
         # to the Nornir driver names ("arista_eos", "cisco_ios", etc.).

--- a/docs/admin/admin_install.md
+++ b/docs/admin/admin_install.md
@@ -58,6 +58,7 @@ PLUGINS_CONFIG = {
         "enable_postprocessing": False,
         "postprocessing_callables": [],
         "postprocessing_subscribed": [],
+        "sync_config_context_repos": False,
         "platform_slug_map": None,
         # "get_custom_compliance": "my.custom_compliance.func"
     },
@@ -102,6 +103,7 @@ The plugin behavior can be controlled with the following list of settings.
 | postprocessing_callables  | ['mypackage.myfunction']      | []      | A list of function paths, in dotted format, that are appended to the available methods for post-processing the intended configuration, for instance, the `render_secrets`. |
 | postprocessing_subscribed | ['mypackage.myfunction']      | []      | A list of function paths, that should exist as postprocessing_callables, that defines the order of application of during the post-processing process.                      |
 | platform_slug_map         | {"cisco_wlc": "cisco_aireos"} | None    | A dictionary in which the key is the platform slug and the value is what netutils uses in any "network_os" parameter.                                                      |
+| sync_config_context_repos | False                         | False   | A boolean to represent whether to synchronize all configured Config Context git repositories during the intended generation.                                                                                               |
 | sot_agg_transposer        | "mypkg.transposer"            | None    | A string representation of a function that can post-process the graphQL data.                                                                                              |
 | per_feature_bar_width     | 0.15                          | 0.15    | The width of the table bar within the overview report                                                                                                                      |
 | per_feature_width         | 13                            | 13      | The width in inches that the overview table can be.                                                                                                                        |

--- a/docs/admin/admin_install.md
+++ b/docs/admin/admin_install.md
@@ -58,7 +58,7 @@ PLUGINS_CONFIG = {
         "enable_postprocessing": False,
         "postprocessing_callables": [],
         "postprocessing_subscribed": [],
-        "sync_config_context_repos": False,
+        "enable_config_context_sync": False,
         "platform_slug_map": None,
         # "get_custom_compliance": "my.custom_compliance.func"
     },
@@ -103,7 +103,7 @@ The plugin behavior can be controlled with the following list of settings.
 | postprocessing_callables  | ['mypackage.myfunction']      | []      | A list of function paths, in dotted format, that are appended to the available methods for post-processing the intended configuration, for instance, the `render_secrets`. |
 | postprocessing_subscribed | ['mypackage.myfunction']      | []      | A list of function paths, that should exist as postprocessing_callables, that defines the order of application of during the post-processing process.                      |
 | platform_slug_map         | {"cisco_wlc": "cisco_aireos"} | None    | A dictionary in which the key is the platform slug and the value is what netutils uses in any "network_os" parameter.                                                      |
-| sync_config_context_repos | False                         | False   | A boolean to represent whether to synchronize all configured Config Context git repositories during the intended generation.                                                                                               |
+| enable_config_context_sync | False                         | False   | A boolean to represent whether to synchronize all configured Config Context git repositories during the intended generation.                                                                                               |
 | sot_agg_transposer        | "mypkg.transposer"            | None    | A string representation of a function that can post-process the graphQL data.                                                                                              |
 | per_feature_bar_width     | 0.15                          | 0.15    | The width of the table bar within the overview report                                                                                                                      |
 | per_feature_width         | 13                            | 13      | The width in inches that the overview table can be.                                                                                                                        |

--- a/nautobot_golden_config/__init__.py
+++ b/nautobot_golden_config/__init__.py
@@ -36,6 +36,7 @@ class GoldenConfig(PluginConfig):
         "per_feature_width": 13,
         "per_feature_height": 4,
         "get_custom_compliance": None,
+        "sync_config_context_repos": False,
     }
 
     def ready(self):

--- a/nautobot_golden_config/__init__.py
+++ b/nautobot_golden_config/__init__.py
@@ -36,7 +36,7 @@ class GoldenConfig(PluginConfig):
         "per_feature_width": 13,
         "per_feature_height": 4,
         "get_custom_compliance": None,
-        "sync_config_context_repos": False,
+        "enable_config_context_sync": False,
     }
 
     def ready(self):

--- a/nautobot_golden_config/__init__.py
+++ b/nautobot_golden_config/__init__.py
@@ -41,6 +41,7 @@ class GoldenConfig(PluginConfig):
 
     def ready(self):
         """Register custom signals."""
+        import nautobot_golden_config.jobs  # pylint: disable=unused-import, import-outside-toplevel
         from nautobot_golden_config.models import ConfigCompliance  # pylint: disable=import-outside-toplevel
 
         from .signals import config_compliance_platform_cleanup  # pylint: disable=import-outside-toplevel

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -15,7 +15,7 @@ from nautobot_golden_config.utilities.constant import (
     ENABLE_BACKUP,
     ENABLE_COMPLIANCE,
     ENABLE_INTENDED,
-    SYNC_CONFIG_CONTEXT_REPOS,
+    ENABLE_CONFIG_CONTEXT_SYNC,
 )
 from nautobot_golden_config.utilities.git import GitRepo
 from nautobot_golden_config.utilities.helper import get_job_filter
@@ -160,7 +160,7 @@ class IntendedJob(Job, FormEntry):
 
         now = datetime.now()
 
-        if SYNC_CONFIG_CONTEXT_REPOS:
+        if ENABLE_CONFIG_CONTEXT_SYNC:
             self.log_debug("Pull Config Context repos.")
             update_config_context_repos(job_obj=self)
 

--- a/nautobot_golden_config/tests/test_jobs.py
+++ b/nautobot_golden_config/tests/test_jobs.py
@@ -1,0 +1,36 @@
+"""Unit tests for nautobot_golden_config Jobs."""
+
+from unittest.mock import MagicMock, patch
+from nautobot.utilities.testing import TransactionTestCase
+
+from nautobot_golden_config.jobs import update_config_context_repos
+
+
+class JobHelperTests(TransactionTestCase):
+    """Unit tests for the helper methods for Jobs."""
+
+    databases = (
+        "default",
+        "job_logs",
+    )
+
+    @patch("nautobot.extras.models.GitRepository.objects.filter")
+    @patch("nautobot_golden_config.jobs.ensure_git_repository")
+    def test_update_config_context_repos_success(
+        self, mock_ensure_git_repo, mock_filter
+    ):  # pylint: disable=no-self-use
+        mock_job_obj = MagicMock()
+        mock_job_obj.job_result = MagicMock()
+        mock_job_obj.log_debug = MagicMock()
+        mock_git_repo = MagicMock()
+        mock_git_repo.name = "Test"
+        mock_git_repo.provided_contents = ["extras.configcontext"]
+        mock_filter.return_value = [mock_git_repo]
+
+        update_config_context_repos(mock_job_obj)
+
+        mock_filter.assert_called_once_with(provided_contents__icontains="extras.configcontext")
+        mock_ensure_git_repo.assert_called_once()
+        mock_ensure_git_repo.assert_called_with(repository_record=mock_git_repo, job_result=mock_job_obj.job_result)
+        mock_job_obj.log_debug.assert_called_once_with("Pulling config context repo Test.")
+        mock_job_obj.job_result.assert_not_called()

--- a/nautobot_golden_config/utilities/constant.py
+++ b/nautobot_golden_config/utilities/constant.py
@@ -16,3 +16,5 @@ CONFIG_FEATURES = {
     "sotagg": ENABLE_SOTAGG,
     "postprocessing": ENABLE_POSTPROCESSING,
 }
+
+SYNC_CONFIG_CONTEXT_REPOS = PLUGIN_CFG.get("sync_config_context_repos")

--- a/nautobot_golden_config/utilities/constant.py
+++ b/nautobot_golden_config/utilities/constant.py
@@ -17,4 +17,4 @@ CONFIG_FEATURES = {
     "postprocessing": ENABLE_POSTPROCESSING,
 }
 
-SYNC_CONFIG_CONTEXT_REPOS = PLUGIN_CFG.get("sync_config_context_repos")
+ENABLE_CONFIG_CONTEXT_SYNC = PLUGIN_CFG.get("enable_config_context_sync")


### PR DESCRIPTION
This PR is to add the capability of having config context repos updated during the Intended Job run so a user always has the latest config data for templates. I attempted to add a test for the method I added but there appears to be something odd with the packaging of this and I can't access the jobs.py file with a patch.