### PR TITLE
log_failure function missing argument

### DIFF
--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -127,7 +127,7 @@ def render_jinja_template(obj, logger, template):
             "Jinja encountered an unexpected TemplateError; check the template for correctness\n"
             f"Template:\n{template}"
         )
-        logger.log_failure(error_msg)
+        logger.log_failure(obj, error_msg)
         raise NornirNautobotException from error
 
 


### PR DESCRIPTION
Hi Team
I just hit that exception because of a configuration error of my plugin settings. And I noticed that additionally the code crashed on the error output. It's only due to a missing argument when calling the log_failure function.

Fixing it helped to raise the real error to the end user.