### PR TITLE
Removing ConfigCompliance model import from 0005 migration

### DIFF
--- a/nautobot_golden_config/migrations/0005_json_compliance_rule.py
+++ b/nautobot_golden_config/migrations/0005_json_compliance_rule.py
@@ -1,11 +1,10 @@
 from django.db import migrations, models
 import json
 
-from nautobot_golden_config.models import ConfigCompliance
-
 
 def jsonify(apps, schedma_editor):
     """Converts textfield to json in preparation for migration."""
+    ConfigCompliance = apps.get_model("nautobot_golden_config", "ConfigCompliance")
     queryset = ConfigCompliance.objects.all()
     attrs = ["actual", "extra", "intended", "missing"]
     for i in queryset:


### PR DESCRIPTION
Loading `ConfigCompliance` from models file worked until we added new model attributes. Once we modified the model, the legacy migration (0005) started to give us errors.

This provides a fix needed by to add new `ConfigCompliance` model attributes. 