### PR TITLE
Minor changes and fixes

### DIFF
--- a/docs/user/app_feature_config_plans.md
+++ b/docs/user/app_feature_config_plans.md
@@ -8,9 +8,6 @@ The current sources of these plans (i.e. plan types) are as follows:
 - The **Missing** configuration of a specific Compliance Feature
 - The **Remediation** configuration of a specific Compliance Feature (*)
 - A **Manual** set of configuration commands
-- A **Full** copy of the entire intended configuration (*)
-
-`(*) These features are not yet fully implemented`
 
 !!! note
     The Intended, Missing and Remediation configuration come from the [Configuration Compliance](./app_feature_compliance.md#compliance-details-view) object that is created when you run the [Perform Configuration Compliance Job](./app_feature_compliance.md#starting-a-compliance-job).

--- a/nautobot_golden_config/__init__.py
+++ b/nautobot_golden_config/__init__.py
@@ -50,12 +50,10 @@ class GoldenConfig(PluginConfig):
             config_compliance_platform_cleanup,
             post_migrate_create_statuses,
             post_migrate_create_job_button,
-            post_migrate_default_enabled_configplan_jobs,
         )
 
         nautobot_database_ready.connect(post_migrate_create_statuses, sender=self)
         nautobot_database_ready.connect(post_migrate_create_job_button, sender=self)
-        nautobot_database_ready.connect(post_migrate_default_enabled_configplan_jobs, sender=self)
 
         super().ready()
         post_migrate.connect(config_compliance_platform_cleanup, sender=ConfigCompliance)

--- a/nautobot_golden_config/choices.py
+++ b/nautobot_golden_config/choices.py
@@ -33,12 +33,10 @@ class ConfigPlanTypeChoice(ChoiceSet):
     TYPE_MISSING = "missing"
     TYPE_REMEDIATION = "remediation"
     TYPE_MANUAL = "manual"
-    TYPE_FULL = "full"
 
     CHOICES = (
         (TYPE_INTENDED, "Intended"),
         (TYPE_MISSING, "Missing"),
         (TYPE_REMEDIATION, "Remediation"),
         (TYPE_MANUAL, "Manual"),
-        (TYPE_FULL, "Full"),
     )

--- a/nautobot_golden_config/filters.py
+++ b/nautobot_golden_config/filters.py
@@ -342,7 +342,9 @@ class ConfigPlanFilterSet(BaseFilterSet, NameSlugSearchFilterSet):
         label="Device Name",
     )
     feature_id = django_filters.ModelMultipleChoiceFilter(
+        field_name="feature__id",
         queryset=models.ComplianceFeature.objects.all(),
+        to_field_name="id",
         label="Feature ID",
     )
     feature = django_filters.ModelMultipleChoiceFilter(

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -516,7 +516,6 @@ class ConfigPlanForm(NautobotModelForm):
                     {"name": "missing", "show": ["id_feature"], "hide": ["id_commands"]},
                     {"name": "intended", "show": ["id_feature"], "hide": ["id_commands"]},
                     {"name": "remediation", "show": ["id_feature"], "hide": ["id_commands"]},
-                    {"name": "full", "show": [], "hide": ["id_commands", "id_feature"]},
                     {"name": "", "show": [], "hide": ["id_commands", "id_feature"]},
                 ],
             }

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -10,7 +10,6 @@ from nautobot.dcim.models import (
     Device,
     DeviceRole,
     DeviceType,
-    Location,
     Manufacturer,
     Platform,
     Rack,
@@ -488,7 +487,8 @@ class ConfigPlanForm(NautobotModelForm):
 
     tenant_group = utilities_forms.DynamicModelMultipleChoiceField(queryset=TenantGroup.objects.all(), required=False)
     tenant = utilities_forms.DynamicModelMultipleChoiceField(queryset=Tenant.objects.all(), required=False)
-    location = utilities_forms.DynamicModelMultipleChoiceField(queryset=Location.objects.all(), required=False)
+    # Requires https://github.com/nautobot/nautobot-plugin-golden-config/issues/430
+    # location = utilities_forms.DynamicModelMultipleChoiceField(queryset=Location.objects.all(), required=False)
     region = utilities_forms.DynamicModelMultipleChoiceField(queryset=Region.objects.all(), required=False)
     site = utilities_forms.DynamicModelMultipleChoiceField(queryset=Site.objects.all(), required=False)
     rack_group = utilities_forms.DynamicModelMultipleChoiceField(queryset=RackGroup.objects.all(), required=False)
@@ -533,7 +533,7 @@ class ConfigPlanForm(NautobotModelForm):
             "feature",
             "commands",
             "tenant",
-            "location",
+            # "location", Requires https://github.com/nautobot/nautobot-plugin-golden-config/issues/430
             "region",
             "site",
             "rack_group",

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -569,6 +569,7 @@ class ConfigPlanUpdateForm(NautobotModelForm):
         model = models.ConfigPlan
         fields = (
             "change_control_id",
+            "change_control_url",
             "tag",
             "status",
         )

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -432,9 +432,6 @@ class GenerateConfigPlans(Job, FormEntry):
         elif self._plan_type in ["manual"]:
             self.log_debug("Starting config plan generation for manual commands.")
             self._generate_config_plan_from_manual()
-        elif self._plan_type in ["full"]:
-            self.log_failure("Full config plan generation is not yet supported.")
-            return
         else:
             self.log_failure(f"Unknown config plan type {self._plan_type}.")
             return

--- a/nautobot_golden_config/signals.py
+++ b/nautobot_golden_config/signals.py
@@ -3,7 +3,6 @@ from django.apps import apps as global_apps
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from nautobot.dcim.models import Platform
-from nautobot.extras.models import Job
 from nautobot_golden_config import models
 
 
@@ -49,13 +48,6 @@ def post_migrate_create_job_button(sender, apps=global_apps, **kwargs):  # pylin
     }
     jobbutton, _ = JobButton.objects.get_or_create(**job_button_config)
     jobbutton.content_types.set([configplan_type])
-
-
-def post_migrate_default_enabled_configplan_jobs(sender, apps=global_apps, **kwargs):  # pylint: disable=unused-argument
-    """Signal to enable ConfigPlan job be default."""
-    cp_job = Job.objects.get(name="Generate Config Plans")
-    cp_job.enabled = True
-    cp_job.save()
 
 
 @receiver(post_save, sender=models.ConfigCompliance)

--- a/nautobot_golden_config/static/run_job.js
+++ b/nautobot_golden_config/static/run_job.js
@@ -85,7 +85,7 @@ function pollJobStatus(jobId) {
         $('#errorDetails').show();
         $('#errorDetails').addClass("alert alert-danger text-center");
         $('#errorDetails').append("Job Started but failed during the Job run. This job may have partially completed. See Job Results for more details on the errors.");
-      } else if (data.status.value in jr_options) {
+      } else if (jr_options.includes(data.status.value)) {
         // Job is still processing, continue polling
         setTimeout(function() {
           pollJobStatus(jobId);

--- a/nautobot_golden_config/static/run_job.js
+++ b/nautobot_golden_config/static/run_job.js
@@ -49,7 +49,7 @@ function startJob(jobClass, data, redirectUrlTemplate) {
             $('#jobStatus').html("failed").show();
             $('#errorDetails').show();
             $('#errorDetails').addClass("alert alert-danger text-center");
-            $('#errorDetails').append("<b>Error: </b>" + e.responseText);
+            $('#errorDetails').html("<b>Error: </b>" + e.responseText);
         }
     });
 }
@@ -84,7 +84,7 @@ function pollJobStatus(jobId) {
       if (["errored", "failed"].includes(data.status.value)) {
         $('#errorDetails').show();
         $('#errorDetails').addClass("alert alert-danger text-center");
-        $('#errorDetails').append("Job Started but failed during the Job run. This job may have partially completed. See Job Results for more details on the errors.");
+        $('#errorDetails').html("Job Started but failed during the Job run. This job may have partially completed. See Job Results for more details on the errors.");
       } else if (jr_options.includes(data.status.value)) {
         // Job is still processing, continue polling
         setTimeout(function() {
@@ -97,7 +97,7 @@ function pollJobStatus(jobId) {
       console.log("error: " + JSON.stringify(e));
       $('#errorDetails').show();
       $('#errorDetails').addClass("alert alert-danger text-center");
-      $('#errorDetails').append("<b>Error: </b>" + e.responseText);
+      $('#errorDetails').html("<b>Error: </b>" + e.responseText);
   }
   });
 }

--- a/nautobot_golden_config/static/run_job.js
+++ b/nautobot_golden_config/static/run_job.js
@@ -68,7 +68,6 @@ function startJob(jobClass, data, redirectUrlTemplate) {
  * @returns {void}
  */
 function pollJobStatus(jobId) {
-  const jr_options = ["running", "pending"];
   $.ajax({
     url: jobId,
     type: "GET",
@@ -84,7 +83,7 @@ function pollJobStatus(jobId) {
         $('#errorDetails').show();
         $('#errorDetails').addClass("alert alert-danger text-center");
         $('#errorDetails').html("Job Started but failed during the Job run. This job may have partially completed. See Job Results for more details on the errors.");
-      } else if (jr_options.includes(data.status.value)) {
+      } else if (["running", "pending"].includes(data.status.value)) {
         // Job is still processing, continue polling
         setTimeout(function() {
           pollJobStatus(jobId);

--- a/nautobot_golden_config/static/run_job.js
+++ b/nautobot_golden_config/static/run_job.js
@@ -40,10 +40,8 @@ function startJob(jobClass, data, redirectUrlTemplate) {
               $('#redirectLink').html(finalUrl).show();
             }
         },
-        complete: function() {
-            $("#loaderImg").hide();
-        },
         error: function(e) {
+            $("#loaderImg").hide();
             console.log("There was an error with your request...");
             console.log("error: " + JSON.stringify(e));
             $('#jobStatus').html("failed").show();
@@ -82,6 +80,7 @@ function pollJobStatus(jobId) {
     success: function(data) {
       $('#jobStatus').html(data.status.value).show();
       if (["errored", "failed"].includes(data.status.value)) {
+        $("#loaderImg").hide();
         $('#errorDetails').show();
         $('#errorDetails').addClass("alert alert-danger text-center");
         $('#errorDetails').html("Job Started but failed during the Job run. This job may have partially completed. See Job Results for more details on the errors.");
@@ -90,9 +89,13 @@ function pollJobStatus(jobId) {
         setTimeout(function() {
           pollJobStatus(jobId);
         }, 1000); // Poll every 1 seconds
-      } 
+      } else if (data.status.value == "completed") {
+        $("#loaderImg").hide();
+        $('#errorDetails').hide();
+      }
     },
     error: function(e) {
+      $("#loaderImg").hide();
       console.log("There was an error with your request...");
       console.log("error: " + JSON.stringify(e));
       $('#errorDetails').show();

--- a/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
@@ -41,7 +41,7 @@
 {% block buttons %}
 {% include "nautobot_golden_config/job_result_modal.html" %}
 
-<a href="#" class="openBtn" data-toggle="modal" data-target="#modalPopup">
+<a href="#" class="openBtn" data-toggle="modal" data-target="#modalPopup" data-backdrop="static" data-keyboard="false">
   <button type="button" id="startJob" class="btn btn-primary">Generate</button>
 </a>
 

--- a/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
@@ -41,7 +41,7 @@
 {% block buttons %}
 {% include "nautobot_golden_config/job_result_modal.html" %}
 
-<a href="#" class="openBtn" data-toggle="modal" data-target="#modalPopup" data-backdrop="static" data-keyboard="false">
+<a href="#" class="openBtn" data-toggle="modal" data-target="#modalPopup" data-backdrop="static">
   <button type="button" id="startJob" class="btn btn-primary">Generate</button>
 </a>
 

--- a/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
@@ -22,6 +22,7 @@
     </span>
     {% render_field form.tenant_group %}
     {% render_field form.tenant %}
+    <!-- {% render_field form.location %} Requires https://github.com/nautobot/nautobot-plugin-golden-config/issues/430 -->
     {% render_field form.region %}
     {% render_field form.site %}
     {% render_field form.rack_group %}

--- a/nautobot_golden_config/templates/nautobot_golden_config/configplan_retrieve.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configplan_retrieve.html
@@ -20,8 +20,18 @@
                 <td>{{ object.plan_type | title }}</td>
             </tr>
             <tr>
-                <td>Feature</td>
-                <td>{% if object.feature %}<a href="{{ object.feature.get_absolute_url }}">{{ object.feature }}</a>{% else %}{{ None | placeholder }}{% endif %}</td>
+                <td>Features</td>
+                <td>
+                    {% if object.feature.exists %}
+                        <ul>
+                            {% for feature in object.feature.all %}
+                                <li><a href="{{ feature.get_absolute_url }}">{{ feature }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        {{ None | placeholder }}
+                    {% endif %}
+                </td>
             </tr>
             <tr>
                 <td>Change Control ID</td>

--- a/nautobot_golden_config/templates/nautobot_golden_config/configplan_retrieve.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configplan_retrieve.html
@@ -42,7 +42,7 @@
                 <td><a href="{{ object.change_control_url }}">{{ object.change_control_url|placeholder }}</a></td>
             </tr>
             <tr>
-                <td>Job Results</td>
+                <td>Job Result</td>
                 <td><a href="{{ object.job_result.get_absolute_url }}">{{ object.job_result|placeholder }}</a></td>
             </tr>
             <tr>

--- a/nautobot_golden_config/templates/nautobot_golden_config/job_result_modal.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/job_result_modal.html
@@ -4,7 +4,7 @@
       <div class="modal-content">
           <!-- Modal Header -->
           <div class="modal-header">
-              <h3 class="modal-title">Running Job</h3>
+              <h3 class="modal-title">Generating Config Plans</h3>
           </div>
 
           <!-- Modal body -->
@@ -23,8 +23,8 @@
                   <td><div id="redirectLink" style="display:none;"></div></td>
                 </tr>
                 <tr>
-                  <td>Error Details: </td>
-                  <td><div id="errorDetails" style="display:none;"></div></td>
+                  <td>Details: </td>
+                  <td><div id="detailMessages" style="display:none;"></div></td>
                 </tr>
                 <tr>
                   <td span="2"><img id="loaderImg" style="display:none;" src="{% static 'img/ajax-loader.gif' %}" alt=""/></td>

--- a/nautobot_golden_config/tests/conftest.py
+++ b/nautobot_golden_config/tests/conftest.py
@@ -1,12 +1,19 @@
 """Params for testing."""
+from datetime import datetime
+import uuid
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.utils.text import slugify
 from nautobot.dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Platform, Rack, RackGroup, Region, Site
 from nautobot.extras.datasources.registry import get_datasource_contents
-from nautobot.extras.models import GitRepository, GraphQLQuery, Status, Tag
+from nautobot.extras.models import GitRepository, GraphQLQuery, Status, Tag, JobResult
 from nautobot.tenancy.models import Tenant, TenantGroup
+import pytz
 from nautobot_golden_config.choices import ComplianceRuleConfigTypeChoice
 from nautobot_golden_config.models import ComplianceFeature, ComplianceRule, ConfigCompliance
+
+
+User = get_user_model()
 
 
 def create_device_data():
@@ -444,3 +451,19 @@ def create_saved_queries() -> None:
         query=query,
     )
     saved_query_5.save()
+
+
+def create_job_result() -> None:
+    """Create a JobResult and return the object."""
+    obj_type = ContentType.objects.get(app_label="extras", model="job")
+    user, _ = User.objects.get_or_create(username="testuser")
+    result = JobResult.objects.create(
+        name="Test-Job-Result",
+        obj_type=obj_type,
+        user=user,
+        job_id=uuid.uuid4(),
+    )
+    result.status = "completed"
+    result.completed = datetime.now(pytz.UTC)
+    result.validated_save()
+    return result

--- a/nautobot_golden_config/tests/test_filters.py
+++ b/nautobot_golden_config/tests/test_filters.py
@@ -8,7 +8,7 @@ from nautobot.extras.models import Status, Tag
 from nautobot.utilities.testing import FilterTestCases
 from nautobot_golden_config import filters, models
 
-from .conftest import create_feature_rule_json, create_device_data, create_feature_rule_cli
+from .conftest import create_feature_rule_json, create_device_data, create_feature_rule_cli, create_job_result
 
 
 class ConfigComplianceModelTestCase(TestCase):
@@ -305,7 +305,7 @@ class ComplianceFeatureModelTestCase(TestCase):
 
 # pylint: disable=too-many-ancestors
 # pylint: disable=too-many-instance-attributes
-class ConfigPlanModelTestCase(FilterTestCases.FilterTestCase):
+class ConfigPlanFilterTestCase(FilterTestCases.FilterTestCase):
     """Test filtering operations for ConfigPlan Model."""
 
     queryset = models.ConfigPlan.objects.all()
@@ -324,39 +324,44 @@ class ConfigPlanModelTestCase(FilterTestCases.FilterTestCase):
         self.status2 = Status.objects.get(name="Approved")
         self.tag1, _ = Tag.objects.get_or_create(name="Tag 1")
         self.tag2, _ = Tag.objects.get_or_create(name="Tag 2")
+        self.job_result1 = create_job_result()
+        self.job_result2 = create_job_result()
         self.config_plan1 = models.ConfigPlan.objects.create(
             device=self.device1,
             plan_type="intended",
             created="2020-01-01",
             config_set="intended test",
-            feature=self.feature1,
             change_control_id="12345",
             status=self.status2,
+            job_result_id=self.job_result1.id,
         )
         self.config_plan1.tags.add(self.tag1)
-        self.config_plan1.save()
+        self.config_plan1.feature.add(self.feature1)
+        self.config_plan1.validated_save()
         self.config_plan2 = models.ConfigPlan.objects.create(
             device=self.device1,
             plan_type="missing",
             created="2020-01-02",
             config_set="missing test",
-            feature=self.feature2,
             change_control_id="23456",
             status=self.status1,
+            job_result_id=self.job_result1.id,
         )
         self.config_plan2.tags.add(self.tag2)
-        self.config_plan2.save()
+        self.config_plan2.feature.add(self.feature2)
+        self.config_plan2.validated_save()
         self.config_plan3 = models.ConfigPlan.objects.create(
             device=self.device2,
             plan_type="remediation",
             created="2020-01-03",
             config_set="remediation test",
-            feature=self.feature1,
             change_control_id="34567",
             status=self.status2,
+            job_result_id=self.job_result2.id,
         )
         self.config_plan3.tags.add(self.tag2)
-        self.config_plan3.save()
+        self.config_plan3.feature.add(self.feature1)
+        self.config_plan3.validated_save()
         self.config_plan4 = models.ConfigPlan.objects.create(
             device=self.device2,
             plan_type="manual",
@@ -364,9 +369,10 @@ class ConfigPlanModelTestCase(FilterTestCases.FilterTestCase):
             config_set="manual test",
             change_control_id="45678",
             status=self.status1,
+            job_result_id=self.job_result1.id,
         )
         self.config_plan4.tags.add(self.tag1)
-        self.config_plan4.save()
+        self.config_plan4.validated_save()
 
     def test_full(self):
         """Test without filtering to ensure all have been added."""
@@ -454,3 +460,12 @@ class ConfigPlanModelTestCase(FilterTestCases.FilterTestCase):
         filterset = self.filterset(params, self.queryset)
         self.assertEqual(filterset.qs.count(), 2)
         self.assertQuerysetEqualAndNotEmpty(filterset.qs, self.queryset.filter(tags__name=self.tag1.name).distinct())
+
+    def test_job_result_id(self):
+        """Test filtering by Job Result ID."""
+        params = {"job_result_id": [self.job_result1.pk]}
+        filterset = self.filterset(params, self.queryset)
+        self.assertEqual(filterset.qs.count(), 3)
+        self.assertQuerysetEqualAndNotEmpty(
+            filterset.qs, self.queryset.filter(job_result_id=self.job_result1.id).distinct()
+        )

--- a/nautobot_golden_config/tests/test_filters.py
+++ b/nautobot_golden_config/tests/test_filters.py
@@ -320,6 +320,8 @@ class ConfigPlanFilterTestCase(FilterTestCases.FilterTestCase):
         self.feature1 = self.rule1.feature
         self.rule2 = create_feature_rule_cli(self.device2, feature="Feature 2")
         self.feature2 = self.rule2.feature
+        self.rule3 = create_feature_rule_cli(self.device1, feature="Feature 3")
+        self.feature3 = self.rule3.feature
         self.status1 = Status.objects.get(name="Not Approved")
         self.status2 = Status.objects.get(name="Approved")
         self.tag1, _ = Tag.objects.get_or_create(name="Tag 1")
@@ -360,7 +362,7 @@ class ConfigPlanFilterTestCase(FilterTestCases.FilterTestCase):
             job_result_id=self.job_result2.id,
         )
         self.config_plan3.tags.add(self.tag2)
-        self.config_plan3.feature.add(self.feature1)
+        self.config_plan3.feature.set([self.feature1, self.feature3])
         self.config_plan3.validated_save()
         self.config_plan4 = models.ConfigPlan.objects.create(
             device=self.device2,

--- a/nautobot_golden_config/tests/test_models.py
+++ b/nautobot_golden_config/tests/test_models.py
@@ -323,6 +323,28 @@ class ConfigPlanModelTestCase(TestCase):
         self.assertEqual(config_plan.status, self.status)
         self.assertEqual(config_plan.plan_type, "intended")
 
+    def test_create_config_plan_intended_multiple_features(self):
+        """Test Create Object."""
+        rule2 = create_feature_rule_json(self.device, feature="feature2")
+        config_plan = ConfigPlan.objects.create(
+            device=self.device,
+            plan_type="intended",
+            config_set="test intended config",
+            change_control_id="1234",
+            change_control_url="https://1234.example.com/",
+            status=self.status,
+            job_result_id=self.job_result.id,
+        )
+        config_plan.feature.set([self.feature, rule2.feature])
+        config_plan.validated_save()
+        self.assertEqual(config_plan.device, self.device)
+        self.assertIn(self.feature.id, config_plan.feature.all().values_list("id", flat=True))
+        self.assertIn(rule2.feature.id, config_plan.feature.all().values_list("id", flat=True))
+        self.assertEqual(config_plan.config_set, "test intended config")
+        self.assertEqual(config_plan.change_control_id, "1234")
+        self.assertEqual(config_plan.status, self.status)
+        self.assertEqual(config_plan.plan_type, "intended")
+
     def test_create_config_plan_missing(self):
         """Test Create Object."""
         config_plan = ConfigPlan.objects.create(

--- a/nautobot_golden_config/tests/test_models.py
+++ b/nautobot_golden_config/tests/test_models.py
@@ -17,7 +17,13 @@ from nautobot_golden_config.models import (
 )
 from nautobot_golden_config.tests.conftest import create_git_repos
 
-from .conftest import create_config_compliance, create_device, create_feature_rule_json, create_saved_queries
+from .conftest import (
+    create_config_compliance,
+    create_device,
+    create_feature_rule_json,
+    create_saved_queries,
+    create_job_result,
+)
 
 
 class ConfigComplianceModelTestCase(TestCase):
@@ -295,19 +301,23 @@ class ConfigPlanModelTestCase(TestCase):
         self.rule = create_feature_rule_json(self.device)
         self.feature = self.rule.feature
         self.status = Status.objects.get(slug="not-approved")
+        self.job_result = create_job_result()
 
     def test_create_config_plan_intended(self):
         """Test Create Object."""
         config_plan = ConfigPlan.objects.create(
             device=self.device,
             plan_type="intended",
-            feature=self.feature,
             config_set="test intended config",
             change_control_id="1234",
+            change_control_url="https://1234.example.com/",
             status=self.status,
+            job_result_id=self.job_result.id,
         )
+        config_plan.feature.add(self.feature)
+        config_plan.validated_save()
         self.assertEqual(config_plan.device, self.device)
-        self.assertEqual(config_plan.feature, self.feature)
+        self.assertEqual(config_plan.feature.first(), self.feature)
         self.assertEqual(config_plan.config_set, "test intended config")
         self.assertEqual(config_plan.change_control_id, "1234")
         self.assertEqual(config_plan.status, self.status)
@@ -318,13 +328,16 @@ class ConfigPlanModelTestCase(TestCase):
         config_plan = ConfigPlan.objects.create(
             device=self.device,
             plan_type="missing",
-            feature=self.feature,
             config_set="test missing config",
             change_control_id="2345",
+            change_control_url="https://2345.example.com/",
             status=self.status,
+            job_result_id=self.job_result.id,
         )
+        config_plan.feature.add(self.feature)
+        config_plan.validated_save()
         self.assertEqual(config_plan.device, self.device)
-        self.assertEqual(config_plan.feature, self.feature)
+        self.assertEqual(config_plan.feature.first(), self.feature)
         self.assertEqual(config_plan.config_set, "test missing config")
         self.assertEqual(config_plan.change_control_id, "2345")
         self.assertEqual(config_plan.status, self.status)
@@ -335,13 +348,16 @@ class ConfigPlanModelTestCase(TestCase):
         config_plan = ConfigPlan.objects.create(
             device=self.device,
             plan_type="remediation",
-            feature=self.feature,
             config_set="test remediation config",
             change_control_id="3456",
+            change_control_url="https://3456.example.com/",
             status=self.status,
+            job_result_id=self.job_result.id,
         )
+        config_plan.feature.add(self.feature)
+        config_plan.validated_save()
         self.assertEqual(config_plan.device, self.device)
-        self.assertEqual(config_plan.feature, self.feature)
+        self.assertEqual(config_plan.feature.first(), self.feature)
         self.assertEqual(config_plan.config_set, "test remediation config")
         self.assertEqual(config_plan.change_control_id, "3456")
         self.assertEqual(config_plan.status, self.status)
@@ -353,6 +369,7 @@ class ConfigPlanModelTestCase(TestCase):
             device=self.device,
             plan_type="manual",
             config_set="test manual config",
+            job_result_id=self.job_result.id,
         )
         self.assertEqual(config_plan.device, self.device)
         self.assertEqual(config_plan.config_set, "test manual config")

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -297,7 +297,7 @@ class GoldenConfigListViewTestCase(TestCase):
         self.assertEqual(device_names_in_export, device_names_in_site_1)
 
 
-# pylint: disable=too-many-ancestors
+# pylint: disable=too-many-ancestors,too-many-locals
 class ConfigPlanTestCase(
     ViewTestCases.GetObjectViewTestCase,
     ViewTestCases.GetObjectChangelogViewTestCase,
@@ -321,6 +321,7 @@ class ConfigPlanTestCase(
         rule1 = create_feature_rule_json(device1, feature="Test Feature 1")
         rule2 = create_feature_rule_json(device2, feature="Test Feature 2")
         rule3 = create_feature_rule_json(device3, feature="Test Feature 3")
+        rule4 = create_feature_rule_json(device3, feature="Test Feature 4")
 
         job_result1 = create_job_result()
         job_result2 = create_job_result()
@@ -360,7 +361,7 @@ class ConfigPlanTestCase(
             status=not_approved_status,
             job_result_id=job_result3.id,
         )
-        plan3.feature.add(rule3.feature)
+        plan3.feature.set([rule3.feature, rule4.feature])
         plan3.validated_save()
 
         # Used for EditObjectViewTestCase

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -17,7 +17,7 @@ from nautobot.extras.models import Relationship, RelationshipAssociation, Status
 from nautobot.utilities.testing import ViewTestCases
 from nautobot_golden_config import views, models
 
-from .conftest import create_feature_rule_json, create_device_data
+from .conftest import create_feature_rule_json, create_device_data, create_job_result
 
 
 User = get_user_model()
@@ -322,37 +322,51 @@ class ConfigPlanTestCase(
         rule2 = create_feature_rule_json(device2, feature="Test Feature 2")
         rule3 = create_feature_rule_json(device3, feature="Test Feature 3")
 
+        job_result1 = create_job_result()
+        job_result2 = create_job_result()
+        job_result3 = create_job_result()
+
         not_approved_status = Status.objects.get(slug="not-approved")
         approved_status = Status.objects.get(slug="approved")
 
-        models.ConfigPlan.objects.create(
+        plan1 = models.ConfigPlan.objects.create(
             device=device1,
             plan_type="intended",
-            feature=rule1.feature,
             config_set="Test Config Set 1",
             change_control_id="Test Change Control ID 1",
+            change_control_url="https://1.example.com/",
             status=not_approved_status,
+            job_result_id=job_result1.id,
         )
-        models.ConfigPlan.objects.create(
+        plan1.feature.add(rule1.feature)
+        plan1.validated_save()
+        plan2 = models.ConfigPlan.objects.create(
             device=device2,
             plan_type="missing",
-            feature=rule2.feature,
             config_set="Test Config Set 2",
             change_control_id="Test Change Control ID 2",
+            change_control_url="https://2.example.com/",
             status=not_approved_status,
+            job_result_id=job_result2.id,
         )
-        models.ConfigPlan.objects.create(
+        plan2.feature.add(rule2.feature)
+        plan2.validated_save()
+        plan3 = models.ConfigPlan.objects.create(
             device=device3,
             plan_type="remediation",
-            feature=rule3.feature,
             config_set="Test Config Set 3",
             change_control_id="Test Change Control ID 3",
+            change_control_url="https://3.example.com/",
             status=not_approved_status,
+            job_result_id=job_result3.id,
         )
+        plan3.feature.add(rule3.feature)
+        plan3.validated_save()
 
         # Used for EditObjectViewTestCase
         cls.form_data = {
             "change_control_id": "Test Change Control ID 4",
+            "change_control_url": "https://4.example.com/",
             "status": approved_status.pk,
         }
 


### PR DESCRIPTION
Changes:
- Fixes the ability to edit change control url
- Disabled the ability to click out of the config plan generation modal - only the 'Close' button works now
- JS: Fixed job polling
- JS: Changed error messages to overwrite previous messages
- Changed Features (on config plan detail view) to show properly
- Changed Job Results (on config plan detail view) to be singular
- Removes signal to enable Generate Config Plans Job by default
- Changes the modal loader image to not hide until the job is done
- Removes `Full` as a type of Config Plan
- JS: Capitalized statuses
- JS: Changed `addClass` to use `attr` instead to overwrite previous classes added without having to keep track of what was added previously
- JS: If the job completed successfully, call the API to find out the number of plans generated. If the count was 0, provide a warning message.
- JS: Changed icon for job result and redirect links and changed the buttons to now load in a new tab
- JS: Changed redirect link icon to not show unless it was successful and it generated at least 1 plan
- Fixes tests
- Disables `Location` options on form

Screenshots:
![Screenshot 2023-08-28 at 2 48 30 PM](https://github.com/nautobot/nautobot-plugin-golden-config/assets/10467633/fc3dad01-d692-45fa-b21e-68c90ecee7cc)
![Screenshot 2023-08-28 at 2 48 02 PM](https://github.com/nautobot/nautobot-plugin-golden-config/assets/10467633/a053c7ec-9c4e-463f-804d-241c1a24d588)