### PR TITLE
Adds URL validation to Config Plan creation form

### DIFF
--- a/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
@@ -74,7 +74,7 @@ function isValidURL(url) {
 
 function openModalAndStartJob() {
   var changeControlUrl = changeControlUrlInput.value;
-  if (!isValidURL(changeControlUrl)) {
+  if (changeControlUrl && !isValidURL(changeControlUrl)) {
     alert("Please enter a valid URL for Change Control URL.");
   } else {
     // If validation passes, trigger the modal to open

--- a/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configplan_create.html
@@ -42,8 +42,8 @@
 {% block buttons %}
 {% include "nautobot_golden_config/job_result_modal.html" with modal_title="Generate Config Plans" %}
 
-<a href="#" class="openBtn" data-toggle="modal" data-target="#modalPopup" data-backdrop="static">
-  <button type="button" id="startJob" class="btn btn-primary">Generate</button>
+<a href="#" id="startJob" class="openBtn" data-backdrop="static">
+  <button type="submit" class="btn btn-primary">Generate</button>
 </a>
 
 {% endblock %}
@@ -65,9 +65,40 @@ function formatJobData(data) {
   delete form_data.q;
   return {"data": form_data};
 }
-var jobClass = "plugins/nautobot_golden_config.jobs/GenerateConfigPlans"
-var redirectUrlTemplate = "/plugins/golden-config/config-plan/?job_result_id={jobData.result.id}"
-document.getElementById("startJob").onclick = function() {startJob(jobClass, formatJobData($("form").serializeArray()), redirectUrlTemplate)};
+
+function isValidURL(url) {
+  // Regular expression to validate URLs
+  var urlPattern = /^(https?:\/\/)?([\w-]+(\.[\w-]+)+|localhost|(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))(:\d+)?(\/\S*)?$/;
+  return urlPattern.test(url);
+}
+
+function openModalAndStartJob() {
+  var changeControlUrl = changeControlUrlInput.value;
+  if (!isValidURL(changeControlUrl)) {
+    alert("Please enter a valid URL for Change Control URL.");
+  } else {
+    // If validation passes, trigger the modal to open
+    $('#modalPopup').modal('show');
+    // Start the job
+    startJob(jobClass, formatJobData($("form").serializeArray()), redirectUrlTemplate);
+  }
+}
+
+var jobClass = "plugins/nautobot_golden_config.jobs/GenerateConfigPlans";
+var redirectUrlTemplate = "/plugins/golden-config/config-plan/?job_result_id={jobData.result.id}";
+var changeControlUrlInput = document.getElementById("id_change_control_url");
+var startJobButton = document.getElementById("startJob");
+var form = document.querySelector("form");
+
+startJobButton.addEventListener("click", function(event) {
+  openModalAndStartJob();
+  event.preventDefault(); // Prevent the default behavior of the anchor link
+});
+
+form.addEventListener("submit", function(event) {
+  openModalAndStartJob();
+  event.preventDefault(); // Prevent the form submission
+});
 
 </script>
 {% endblock javascript %}


### PR DESCRIPTION
Currently, there is no URL validation on the creation form since it just gets sent to the Job. The options for URL validation are now either 1) validate and fail the job or 2) validate via JS. I spoke with Jeff and he said he'd rather it fail earlier, so this adds a validation to the JS.

Other changes:
- Removed HTML calling the modal directly (removed `data-target`) as the JS will now call it
- Change the button from `button` class to `submit` so you can hit the Enter key to submit the form as well as click the button

_Co-authored by: ChatGPT_

Why this is needed:
If you enter an invalid URL into the form submission it will run the job and create N number of config plans, all with that invalid URL. As soon as you try and edit (individually or bulk edit) any other field on those objects it will fail validation. In the case of the individual edit the form validation catches it and shows you that it is an invalid URL. In the case of bulk edit, it just reloads the page with no visible error on why.