### PR TITLE
Fix Missing Fields from Multiple Device Compliance Jobs

### DIFF
--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -187,7 +187,7 @@ class BackupJob(Job, FormEntry):
             backup_repo.push()
 
 
-class AllGoldenConfig(Job):
+class AllGoldenConfig(Job, FormEntry):
     """Job to to run all three jobs against a single device."""
 
     device = ObjectVar(model=Device, required=True)
@@ -211,7 +211,7 @@ class AllGoldenConfig(Job):
             ComplianceJob().run.__func__(self, data, True)  # pylint: disable=too-many-function-args
 
 
-class AllDevicesGoldenConfig(Job):
+class AllDevicesGoldenConfig(Job, FormEntry):
     """Job to to run all three jobs against multiple devices."""
 
     class Meta:

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -187,7 +187,7 @@ class BackupJob(Job, FormEntry):
             backup_repo.push()
 
 
-class AllGoldenConfig(Job, FormEntry):
+class AllGoldenConfig(Job):
     """Job to to run all three jobs against a single device."""
 
     device = ObjectVar(model=Device, required=True)


### PR DESCRIPTION
It was found that the Multiple Devices Jobs were missing the fields to allow filtering the Devices to execute the Jobs against. It appears this is due to missing the FormEntry mixin class.