### PR TITLE
Use helper function to lazy load jinja filters from django template engine.

### DIFF
--- a/nautobot_golden_config/nornir_plays/config_intended.py
+++ b/nautobot_golden_config/nornir_plays/config_intended.py
@@ -22,6 +22,7 @@ from nautobot_golden_config.utilities.constant import JINJA_ENV
 from nautobot_golden_config.utilities.db_management import close_threaded_db_connections
 from nautobot_golden_config.utilities.graphql import graph_ql_query
 from nautobot_golden_config.utilities.helper import (
+    add_django_jinja_filters_to_env,
     get_device_to_settings_map,
     get_job_filter,
     render_jinja_template,
@@ -33,9 +34,6 @@ LOGGER = logging.getLogger(__name__)
 
 # Use a custom Jinja2 environment instead of Django's to avoid HTML escaping
 jinja_env = SandboxedEnvironment(**JINJA_ENV)
-
-# Retrieve filters from the Django jinja template engine
-jinja_env.filters = engines["jinja"].env.filters
 
 
 @close_threaded_db_connections
@@ -119,6 +117,9 @@ def config_intended(nautobot_job, data):
 
     for settings in set(device_to_settings_map.values()):
         verify_settings(logger, settings, ["jinja_path_template", "intended_path_template", "sot_agg_query"])
+
+    # Retrieve filters from the Django jinja template engine
+    add_django_jinja_filters_to_env(jinja_env)
 
     try:
         with InitNornir(

--- a/nautobot_golden_config/nornir_plays/config_intended.py
+++ b/nautobot_golden_config/nornir_plays/config_intended.py
@@ -4,7 +4,6 @@ import logging
 import os
 from datetime import datetime
 
-from django.template import engines
 from jinja2.sandbox import SandboxedEnvironment
 from nautobot_plugin_nornir.constants import NORNIR_SETTINGS
 from nautobot_plugin_nornir.plugins.inventory.nautobot_orm import NautobotORMInventory

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -4,6 +4,7 @@ import json
 
 from django.contrib import messages
 from django.db.models import Q
+from django.template import engines
 from django.utils.html import format_html
 from django.urls import reverse
 
@@ -94,6 +95,18 @@ def verify_settings(logger, global_settings, attrs):
         if not getattr(global_settings, item):
             logger.log_failure(None, f"Missing the required global setting: `{item}`.")
             raise NornirNautobotException()
+
+
+def add_django_jinja_filters_to_env(jinja_env):
+    """Load Django Jinja filters from the Django jinja template engine, and add them to the provided jinja_env.
+
+    Args:
+        jinja_env: The jinja environment to be modified.
+
+    Returns:
+        None
+    """
+    jinja_env.filters = engines["jinja"].env.filters
 
 
 def render_jinja_template(obj, logger, template):


### PR DESCRIPTION
This fixes an issue where `django_jinga.backends.Jinja2` is instantiated prematurely in a Nautobot installation, possibly preventing Jinja filters from other plugins being loaded into the jinja environment. 