### PR TITLE
Use dynamic_groups_cached

### DIFF
--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -157,8 +157,10 @@ def get_device_to_settings_map(queryset):
     """Helper function to map settings to devices."""
     device_to_settings_map = {}
     for device in queryset:
-        dynamic_group = DynamicGroup.objects.filter(golden_config_setting__isnull=False).get_for_object(device, use_cache=True).order_by(
-            "-golden_config_setting__weight"
+        dynamic_group = (
+            DynamicGroup.objects.filter(golden_config_setting__isnull=False)
+            .get_for_object(device, use_cache=True)
+            .order_by("-golden_config_setting__weight")
         )
         if dynamic_group.exists():
             device_to_settings_map[device.id] = dynamic_group.first().golden_config_setting

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -156,7 +156,7 @@ def get_device_to_settings_map(queryset):
     """Helper function to map settings to devices."""
     device_to_settings_map = {}
     for device in queryset:
-        dynamic_group = device.dynamic_groups.exclude(golden_config_setting__isnull=True).order_by(
+        dynamic_group = device.dynamic_groups_cached.exclude(golden_config_setting__isnull=True).order_by(
             "-golden_config_setting__weight"
         )
         if dynamic_group.exists():

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -12,6 +12,7 @@ from jinja2 import exceptions as jinja_errors
 from jinja2.sandbox import SandboxedEnvironment
 from nautobot.dcim.filters import DeviceFilterSet
 from nautobot.dcim.models import Device
+from nautobot.extras.models import DynamicGroup
 from nautobot.utilities.utils import render_jinja2
 from nornir_nautobot.exceptions import NornirNautobotException
 

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -156,7 +156,7 @@ def get_device_to_settings_map(queryset):
     """Helper function to map settings to devices."""
     device_to_settings_map = {}
     for device in queryset:
-        dynamic_group = device.dynamic_groups_cached.exclude(golden_config_setting__isnull=True).order_by(
+        dynamic_group = DynamicGroup.objects.filter(golden_config_setting__isnull=False).get_for_object(device, use_cache=True).order_by(
             "-golden_config_setting__weight"
         )
         if dynamic_group.exists():


### PR DESCRIPTION
Updated settings retrieval to use `dynamic_groups_cached` to take advantage of caching when enabled.

Also updates the query to only evaluate those Dynamic Groups which are a part of GC, instead of evaluating all and then excluding.