### PR TITLE
Fix network_driver_mapper

### DIFF
--- a/nautobot_golden_config/nornir_plays/config_compliance.py
+++ b/nautobot_golden_config/nornir_plays/config_compliance.py
@@ -70,12 +70,12 @@ def get_config_element(rule, config, obj, logger):
             config_element = config_json
 
     elif rule["obj"].config_type == ComplianceRuleConfigTypeChoice.TYPE_CLI:
-        if obj.platform.network_driver_mapper["netmiko"] not in parser_map.keys():
+        if obj.platform.network_driver_mappings["netmiko"] not in parser_map.keys():
             error_msg = f"E3003: There is currently no CLI-config parser support for platform network_driver `{obj.platform.network_driver}`, preemptively failed."
             logger.error(error_msg, extra={"object": obj})
             raise NornirNautobotException(error_msg)
 
-        config_element = section_config(rule, config, obj.platform.network_driver_mapper["netmiko"])
+        config_element = section_config(rule, config, obj.platform.network_driver_mappings["netmiko"])
 
     else:
         error_msg = f"E3004: There rule type ({rule['obj'].config_type}) is not recognized."


### PR DESCRIPTION
Replace `obj.platform.network_driver_mapper` with `network_driver_mappings`

```
In [11]: Platform.objects.all()[5].network_driver_mappings
Out[11]:
{'ansible': 'cisco.nxos.nxos',
 'hier_config': 'nxos',
 'napalm': 'nxos',
 'netmiko': 'cisco_nxos',
 'netutils_parser': 'cisco_nxos',
 'ntc_templates': 'cisco_nxos',
 'pyats': 'nxos',
 'pyntc': 'cisco_nxos_nxapi',
 'scrapli': 'cisco_nxos'}

In [12]: Platform.objects.all()[5].network_driver
Out[12]: 'cisco_nxos'
```

```
if obj.platform.network_driver_mapper["netmiko"] not in parser_map.keys():
```